### PR TITLE
Add matrixBuildStep

### DIFF
--- a/vars/matrixBuild.groovy
+++ b/vars/matrixBuild.groovy
@@ -1,0 +1,31 @@
+#!/usr/bin/env groovy
+
+def call(Map config, Closure body) {
+  if(!config.label) {
+    error "Please provide a label to run the body"
+  }
+
+  def labelQuery = config.label
+  def jobLabel = config.name ?: "matrixBuild"
+
+  def nodes = nodesByLabel(label:labelQuery)
+  
+  if(nodes.isEmpty()) {
+    error "No execution node available with label ${labelQuery}."
+  }
+
+  def stepsToExecuteParallel = nodes.collectEntries { String nodeName ->
+    ["${jobLabel}-${nodeName}" : executeOnNode(nodeName, body)]
+  }
+  parallel stepsToExecuteParallel
+}
+
+def executeOnNode(String nodeName, Closure body) {
+  return {
+    node(nodeName) {
+      if (body) {
+        body.call(nodeName)
+      }
+    }
+  }
+}

--- a/vars/matrixBuild.txt
+++ b/vars/matrixBuild.txt
@@ -1,0 +1,3 @@
+execute body on all machines matching the provided label.
+* label Computer name, label name, or any other label expression like linux && 64bit to restrict where this step builds. May be left blank, in which case any available executor is taken. Supported operators
+* name A descriptive name for this step for the build log


### PR DESCRIPTION
## Description

This patch adds a new utility step `matrixBuild` to the pipeline library. The step allows to schedule a closure body on multiple nodes in parallel. This step replaces the old matrix build job in jenkins.

Usage
-------

```groovy
#!groovy
@Library('github.com/wooga/atlas-jenkins-pipeline@matrixStep') _

matrixBuild(label: "machineName || label", name: "optional name for the step") { nodeName ->
  println("I run in parallel on node: ${nodeName}")
}
```

Changes
=======

![ADD] ![NEW] build step `matrixBuild`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"