### PR TITLE
Add publish of WDK code coverage reports

### DIFF
--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -150,6 +150,8 @@ def call(Map config = [unityVersions:[]]) {
                     nunit failIfNoResults: false, testResultsPattern: '**/build/reports/unity/**/*.xml'
                     archiveArtifacts artifacts: '**/build/logs/**/*.log', allowEmptyArchive: true
                     archiveArtifacts artifacts: '**/build/reports/unity/**/*.xml' , allowEmptyArchive: true
+                    archiveArtifacts artifacts: '**/build/codeCoverage/**/*.xml' , allowEmptyArchive: true
+                    publishCoverage adapters: [istanbulCoberturaAdapter('**/codeCoverage/Cobertura.xml')], sourceFileResolver: sourceFiles('NEVER_STORE')
                     dir (version) {
                       deleteDir()
                     }

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -150,7 +150,6 @@ def call(Map config = [unityVersions:[]]) {
                     nunit failIfNoResults: false, testResultsPattern: '**/build/reports/unity/**/*.xml'
                     archiveArtifacts artifacts: '**/build/logs/**/*.log', allowEmptyArchive: true
                     archiveArtifacts artifacts: '**/build/reports/unity/**/*.xml' , allowEmptyArchive: true
-                    archiveArtifacts artifacts: '**/build/codeCoverage/**/*.xml' , allowEmptyArchive: true
                     publishCoverage adapters: [istanbulCoberturaAdapter('**/codeCoverage/Cobertura.xml')], sourceFileResolver: sourceFiles('NEVER_STORE')
                     dir (version) {
                       deleteDir()

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -150,7 +150,7 @@ def call(Map config = [unityVersions:[]]) {
                     nunit failIfNoResults: false, testResultsPattern: '**/build/reports/unity/**/*.xml'
                     archiveArtifacts artifacts: '**/build/logs/**/*.log', allowEmptyArchive: true
                     archiveArtifacts artifacts: '**/build/reports/unity/**/*.xml' , allowEmptyArchive: true
-                    publishCoverage adapters: [istanbulCoberturaAdapter('**/codeCoverage/Cobertura.xml')], sourceFileResolver: sourceFiles('NEVER_STORE')
+                    publishCoverage adapters: [istanbulCoberturaAdapter('**/codeCoverage/Cobertura.xml')], sourceFileResolver: sourceFiles('STORE_LAST_BUILD')
                     dir (version) {
                       deleteDir()
                     }


### PR DESCRIPTION
## Description
Publish (if present) `Cobertura` formated coverage report after the test runs. 
Uses the [Jenkins code coverage plugin](https://www.jenkins.io/doc/pipeline/steps/code-coverage-api/)
Currently configured as: don't store code, don't fail on missing report, no thresholds
