### PR TITLE
WDK build checks only running on last provided Unity version

### DIFF
--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -117,10 +117,10 @@ def call(Map config = [unityVersions:[]]) {
 
                   if(config.testEnvironment) {
                     if(config.testEnvironment instanceof List) {
-                      environment = config.testEnvironment
+                      environment.addAll(config.testEnvironment)
                     }
                     else {
-                      environment = (config.testEnvironment[it]) ?: []
+                      environment.addAll( (config.testEnvironment[it]) ?: [])
                     }
                   }
 


### PR DESCRIPTION
## Description

Environment for the checks in WDKAutoSwitch is ending up referencing global config.testEnvironemnt. Overwriting used Unity Version.

## Changes

* ![FIX] WDK checks only running on last provided Unity version
 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
