### PR TITLE
Add buildJavaLibraryOSSRH

### DIFF
--- a/src/net/wooga/jenkins/pipeline/TestHelper.groovy
+++ b/src/net/wooga/jenkins/pipeline/TestHelper.groovy
@@ -7,7 +7,10 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 **/
 def transformIntoCheckStep(platform, testEnvironment, coverallsToken, config, checkClosure, finallyClosure, skipcheckout = false) {
   return {
-    def node_label = "${platform} && atlas"
+    def node_label = "atlas"
+    if(platform) {
+      node_label += "&& ${platform}"
+    }
 
     if(config.labels) {
       node_label += "&& ${config.labels}"
@@ -64,10 +67,6 @@ def transformIntoCheckStep(platform, testEnvironment, coverallsToken, config, ch
             }
           }
         }
-      }
-      catch(Exception error) {
-        echo error.message
-        currentBuild.result = 'FAILURE'
       }
       finally {
         finallyClosure.call()

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -1,0 +1,157 @@
+#!/usr/bin/env groovy
+
+import net.wooga.jenkins.pipeline.TestHelper
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                                                    //
+// Step buildJavaLibraryOSSRH                                                                                         //
+//                                                                                                                    //
+//                                                                                                                    //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+def call(Map config = [:]) {
+      //set config defaults
+    config.platforms = config.plaforms ?: ['unix']
+    config.platforms = config.platforms ?: ['unix']
+    config.testEnvironment = config.testEnvironment ?: []
+    config.testLabels = config.testLabels ?: []
+    config.labels = config.labels ?: ''
+    config.dockerArgs = config.dockerArgs ?: [:]
+    config.dockerArgs.dockerFileName = config.dockerArgs.dockerFileName ?: "Dockerfile"
+    config.dockerArgs.dockerFileDirectory = config.dockerArgs.dockerFileDirectory ?: "."
+    config.dockerArgs.dockerBuildArgs = config.dockerArgs.dockerBuildArgs ?: []
+    config.dockerArgs.dockerArgs = config.dockerArgs.dockerArgs ?: []
+
+    def platforms = config.platforms
+    def mainPlatform = platforms[0] == '' ? 'unix' : platforms[0] 
+    def helper = new TestHelper()
+
+    pipeline {
+        agent none
+
+        options {
+            buildDiscarder(logRotator(artifactNumToKeepStr: '40'))
+        }
+
+        parameters {
+            choice(choices: "snapshot\nrc\nfinal", description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+            choice(choices: "\npatch\nminor\nmajor", description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+        }
+
+        stages {
+            stage('Preparation') {
+                agent any
+
+                steps {
+                    sendSlackNotification "STARTED", true
+                }
+            }
+
+            stage("check") {
+                when {
+                    beforeAgent true
+                    expression {
+                        return params.RELEASE_TYPE == "snapshot"
+                    }
+                }
+
+                steps {
+                    script {
+                        def stepsForParallel = platforms.collectEntries {
+                            def environment = []
+                            def labels = config.labels
+
+                            if (config.testEnvironment) {
+                                if (config.testEnvironment instanceof List) {
+                                    environment = config.testEnvironment
+                                } else {
+                                    environment = (config.testEnvironment[it]) ?: []
+                                }
+                            }
+
+                            environment << "COVERALLS_PARALLEL=true"
+
+                            if (config.testLabels) {
+                                if (config.testLabels instanceof List) {
+                                    labels = config.testLabels
+                                } else {
+                                    labels = (config.testLabels[it]) ?: config.labels
+                                }
+                            }
+
+                            def testConfig = config.clone()
+                            testConfig.labels = labels
+
+                            def checkStep = { gradleWrapper "check" }
+                            def finalizeStep = {
+                                if (!currentBuild.result) {
+                                    def command = (config.coverallsToken) ? "jacocoTestReport coveralls" : "jacocoTestReport"
+                                    withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {
+                                        gradleWrapper command
+                                        publishHTML([
+                                                allowMissing         : true,
+                                                alwaysLinkToLastBuild: true,
+                                                keepAll              : true,
+                                                reportDir            : 'build/reports/jacoco/test/html',
+                                                reportFiles          : 'index.html',
+                                                reportName           : "Coverage ${it}",
+                                                reportTitles         : ''
+                                        ])
+                                    }
+                                }
+                                junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
+                                cleanWs()
+                            }
+
+                            ["check ${it}": helper.transformIntoCheckStep(it, environment, config.coverallsToken, testConfig, checkStep, finalizeStep)]
+                        }
+
+                        parallel stepsForParallel
+                    }
+                }
+
+                post {
+                    success {
+                        httpRequest httpMode: 'POST', ignoreSslErrors: true, url: "https://coveralls.io/webhook?repo_token=${config.coverallsToken}"
+                    }
+                }
+            }
+
+            stage('publish') {
+                agent {
+                    label "$mainPlatform && atlas"
+                }
+
+                environment {
+                    OSSRH = credentials('ossrh.publish')
+                    OSSRH_SIGNING_KEY = credentials('ossrh.signing.key')
+                    OSSRH_SIGNING_KEY_ID = credentials('ossrh.signing.key_id')
+                    OSSRH_SIGNING_PASSPHRASE = credentials('ossrh.signing.passphrase')
+                    OSSRH_USERNAME = "${OSSRH_USR}"
+                    OSSRH_PASSWORD = "${OSSRH_PSW}"
+                    GRGIT = credentials('github_up')
+                    GRGIT_USER = "${GRGIT_USR}"
+                    GRGIT_PASS = "${GRGIT_PSW}"
+                    GITHUB_LOGIN = "${GRGIT_USR}"
+                    GITHUB_PASSWORD = "${GRGIT_PSW}"
+                }
+
+                steps {
+                    gradleWrapper "${params.RELEASE_TYPE.trim()} -Prelease.stage=${params.RELEASE_TYPE.trim()} -Prelease.scope=${params.RELEASE_SCOPE} -x check"
+                }
+
+                post {
+                    cleanup {
+                        cleanWs()
+                    }
+                }
+            }
+        }
+
+        post {
+            always {
+                sendSlackNotification currentBuild.result, true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

I need to add a new buildJavaLibrary step which can publish to OSSRH. The old step is using bintray credentials and can't really be reused or extended. For the future 2.x version of the pipelines I plan to fix the naming schemes and maybe move the publish configuration out of the general pipeline.

I also fixed a runtime bug in this pipeline. With OSSRH it is possible to publish also snapshot builds. The try..catch setup was broken and never discovered as most pipelines skip the publish step on normal ci runs and skip the check stage on publish. The pipeline still executed the publish stage even though the check stage failed. I removed the catch statement which just printed the error message. Now a failing tests stopps the pipeline.

I also adjusted the TestHelper class to allow null or empty values for the platform parameter.

## Changes

* ![ADD] new step `buildJavaLibraryOSSRH`
* ![FIX] `publish` stage execution after failing `checks` stage
* ![IMPROVE] `Testhelperi#transformIntoCheckStep` make `platform` optional

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"