### PR TITLE
Add optional unity version support

### DIFF
--- a/src/net/wooga/jenkins/pipeline/BuildUtils.groovy
+++ b/src/net/wooga/jenkins/pipeline/BuildUtils.groovy
@@ -1,0 +1,52 @@
+package net.wooga.jenkins.pipeline
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+
+class BuildVersion {
+    final String version
+    final Boolean optional
+
+    BuildVersion(version, optional) {
+        this.version = version
+        this.optional = optional
+    }
+
+    @Override
+    @NonCPS
+    String toString() {
+        return version
+    }
+}
+
+/**
+ * For each entry in a versions map, if they are not in the standard format
+ * we process them into the newer format that supports optional arguments per version
+ * (such as if it's optional, etc).
+ * Example: '3001.x' -> [ version : '3001.x', optional : false ]
+ * @param versions
+ * @return
+ */
+def parseVersions(versions) {
+
+    final versionKey = "version"
+    final optionalKey = "optional"
+
+    versions.collect { v ->
+
+        if (v instanceof Closure) {
+            v = v.call()
+        }
+
+        if (v instanceof Map) {
+            if (!v.containsKey(versionKey)) {
+                throw new Exception("Entry ${v} does not contain ${versionKey}")
+            }
+            if (!v.containsKey(optionalKey)) {
+                throw new Exception("Entry ${v} does not contain ${optionalKey}")
+            }
+            return new BuildVersion(v[versionKey], v[optionalKey])
+        }
+
+        return new BuildVersion(v.toString(), false)
+    }
+}

--- a/src/net/wooga/jenkins/pipeline/TestHelper.groovy
+++ b/src/net/wooga/jenkins/pipeline/TestHelper.groovy
@@ -5,14 +5,11 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 /**
  * Creates a "check" step for use in a jenkins pipeline
  **/
-def transformIntoCheckStep(String platform, Map testEnvironment, String coverallsToken, Map config, Closure checkClosure, Closure finallyClosure, Boolean skipCheckout = false) {
-
-    return this.createCheckStep(args)
-    this.createCheckStep([platform: platform,
+Closure transformIntoCheckStep(platform, testEnvironment, coverallsToken, config, checkClosure, finallyClosure, skipCheckout = false) {
+    return this.createCheckStep([platform: platform,
             testEnvironment: testEnvironment,
             config: config,
             checkClosure: checkClosure,
-            catchClosure: catchClosure,
             finallyClosure: finallyClosure,
             skipCheckout: skipCheckout])
 }
@@ -20,7 +17,10 @@ def transformIntoCheckStep(String platform, Map testEnvironment, String coverall
 /**
  * Creates a "check" step for use in a jenkins pipeline
  **/
-def createCheckStep(Map args) {
+Closure createCheckStep(Map args) {
+    args.config = args.config ?: [:]
+    args.config.dockerArgs = args.config.dockerArgs ?: [:]
+    args.skipCheckout = args.skipCheckout ?: false
 
     return {
         def node_label = "atlas"

--- a/src/net/wooga/jenkins/pipeline/TestHelper.groovy
+++ b/src/net/wooga/jenkins/pipeline/TestHelper.groovy
@@ -3,76 +3,99 @@ package net.wooga.jenkins.pipeline
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 /**
-* Creates a step closure from a unity version string.
-**/
-def transformIntoCheckStep(platform, testEnvironment, coverallsToken, config, checkClosure, finallyClosure, skipcheckout = false) {
-  return {
-    def node_label = "atlas"
-    if(platform) {
-      node_label += "&& ${platform}"
-    }
+ * Creates a "check" step for use in a jenkins pipeline
+ **/
+def transformIntoCheckStep(String platform, Map testEnvironment, String coverallsToken, Map config, Closure checkClosure, Closure finallyClosure, Boolean skipCheckout = false) {
 
-    if(config.labels) {
-      node_label += "&& ${config.labels}"
-    }
+    return this.createCheckStep(args)
+    this.createCheckStep([platform: platform,
+            testEnvironment: testEnvironment,
+            config: config,
+            checkClosure: checkClosure,
+            catchClosure: catchClosure,
+            finallyClosure: finallyClosure,
+            skipCheckout: skipCheckout])
+}
 
-    if(platform == "linux") {
-      node_label = "linux && docker"
-    }
+/**
+ * Creates a "check" step for use in a jenkins pipeline
+ **/
+def createCheckStep(Map args) {
 
-    def dockerArgs = config.dockerArgs
-
-    node(node_label) {
-      try {
-        testEnvironment = testEnvironment.collect { item ->
-          if(item instanceof groovy.lang.Closure) {
-            return item.call().toString()
-          }
-
-          return item.toString()
+    return {
+        def node_label = "atlas"
+        if (args.platform) {
+            node_label += "&& ${args.platform}"
         }
 
-        if(!skipcheckout) {
-          checkout scm
+        if (args.config.labels) {
+            node_label += "&& ${args.config.labels}"
         }
 
-        withEnv(["TRAVIS_JOB_NUMBER=${BUILD_NUMBER}.${platform.toUpperCase()}"]) {
-          withEnv(testEnvironment) {
-            if(platform == "linux") {
-              def image = null
-              if(dockerArgs.dockerImage) {
-                echo "Use docker image ${dockerArgs.dockerImage}"
-                image = docker.image(dockerArgs.dockerImage)
-              } else {
-                def dockerFilePath = "${dockerArgs.dockerFileDirectory}/${dockerArgs.dockerFileName}"
-                echo "Dockerfile Path: ${dockerFilePath}"
+        if (args.platform == "linux") {
+            node_label = "linux && docker"
+        }
 
-                if(!fileExists(dockerFilePath)) {
-                  checkClosure.call()
-                  return
+        def dockerArgs = args.config.dockerArgs
+
+        node(node_label) {
+            try {
+                testEnvironment = args.testEnvironment.collect { item ->
+                    if (item instanceof groovy.lang.Closure) {
+                        return item.call().toString()
+                    }
+
+                    return item.toString()
                 }
 
-                def dockerfileContent = readFile(dockerFilePath)
-                def buildArgs = dockerArgs.dockerBuildArgs.join(' ')
-                def hash = Utils.stringToSHA1(dockerfileContent + "/n" + buildArgs)
-                image = docker.build(hash, "-f ${dockerArgs.dockerFileName} " + buildArgs + " ${dockerArgs.dockerFileDirectory}")
-              }
+                if (!args.skipCheckout) {
+                    checkout scm
+                }
 
-              def args = dockerArgs.dockerArgs.join(' ')
-              image.inside(args) {
-                checkClosure.call()
-              }
-            } else {
-              checkClosure.call()
+                withEnv(["TRAVIS_JOB_NUMBER=${BUILD_NUMBER}.${args.platform.toUpperCase()}"]) {
+                    withEnv(args.testEnvironment) {
+                        if (args.platform == "linux") {
+                            def image = null
+                            if (dockerArgs.dockerImage) {
+                                echo "Use docker image ${dockerArgs.dockerImage}"
+                                image = docker.image(dockerArgs.dockerImage)
+                            } else {
+                                def dockerFilePath = "${dockerArgs.dockerFileDirectory}/${dockerArgs.dockerFileName}"
+                                echo "Dockerfile Path: ${dockerFilePath}"
+
+                                if (!fileExists(dockerFilePath)) {
+                                    args.checkClosure.call()
+                                    return
+                                }
+
+                                def dockerfileContent = readFile(dockerFilePath)
+                                def buildArgs = dockerArgs.dockerBuildArgs.join(' ')
+                                def hash = Utils.stringToSHA1(dockerfileContent + "/n" + buildArgs)
+                                image = docker.build(hash, "-f ${dockerArgs.dockerFileName} " + buildArgs + " ${dockerArgs.dockerFileDirectory}")
+                            }
+
+                            def imageArgs = dockerArgs.dockerArgs.join(' ')
+                            image.inside(imageArgs) {
+                                args.checkClosure.call()
+                            }
+                        } else {
+                            args.checkClosure.call()
+                        }
+                    }
+                }
             }
-          }
+            catch (Exception e) {
+                if (args.catchClosure) {
+                    args.catchClosure.call(e)
+                } else {
+                    throw e
+                }
+            }
+            finally {
+                args.finallyClosure.call()
+            }
         }
-      }
-      finally {
-        finallyClosure.call()
-      }
     }
-  }
 }
 
 return this

--- a/vars/sendSlackNotification.groovy
+++ b/vars/sendSlackNotification.groovy
@@ -25,14 +25,20 @@ def call(String buildStatus = 'STARTED', blueOceanURL = false) {
   if (buildStatus == 'STARTED') {
     colorCode = '#FFFF00'
     buildStatus = buildStatus.toLowerCase().capitalize()
-  } else if (buildStatus == 'SUCCESSFUL') {
+  }
+  else if (buildStatus == 'SUCCESSFUL') {
     colorCode = '#00FF00'
     buildStatus = buildStatus.toLowerCase().capitalize()
   }
   else if (buildStatus == 'SUCCESS') {
      colorCode = '#00FF00'
      buildStatus = buildStatus.toLowerCase().capitalize()
-  } else {
+  }
+  else if (buildStatus == 'UNSTABLE') {
+    colorCode = '#F5A623'
+    buildStatus = buildStatus.toLowerCase().capitalize()
+  }
+  else {
     colorCode = '#FF0000'
     buildStatus = buildStatus.toLowerCase().capitalize()
   }


### PR DESCRIPTION
## Description

Provides support for setting optional unity versions to the pipeline through the refactoring of how the versions were parsed and how the existing method works (it now redirects to a newer implementation that takes a map as an argument.

Example:
![image](https://user-images.githubusercontent.com/10147802/109501874-829ee080-7a98-11eb-828f-95f744f77fba.png)

## Changes

![ADD] support for optional unity test versions

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"