### PR TITLE
Add API compatibility level to the unity WDK AutoSwitch task

### DIFF
--- a/src/net/wooga/jenkins/pipeline/BuildUtils.groovy
+++ b/src/net/wooga/jenkins/pipeline/BuildUtils.groovy
@@ -3,18 +3,46 @@ package net.wooga.jenkins.pipeline
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 class BuildVersion {
+
     final String version
     final Boolean optional
+    // NET_4_6, NET_Standard_2_0 (DEFAULT)
+    final String apiCompatibilityLevel
 
-    BuildVersion(version, optional) {
+    BuildVersion(version, optional, apiCompatibilityLevel = null) {
         this.version = version
         this.optional = optional
+        this.apiCompatibilityLevel = apiCompatibilityLevel
     }
 
     @Override
     @NonCPS
     String toString() {
         return version
+    }
+
+    @NonCPS
+    String toLabel(){
+        def result = version
+        if (optional){
+            result += " (optional)"
+        }
+        if (apiCompatibilityLevel != null) {
+            result += " (${apiCompatibilityLevel})"
+        }
+        return result
+    }
+
+    @NonCPS
+    String toDirectoryName(){
+        def result = version
+        if (optional){
+            result += "_optional"
+        }
+        if (apiCompatibilityLevel != null) {
+            result += "_${apiCompatibilityLevel}"
+        }
+        return result
     }
 }
 
@@ -30,6 +58,7 @@ def parseVersions(versions) {
 
     final versionKey = "version"
     final optionalKey = "optional"
+    final apiCompatibilityLevelKey = "apiCompatibilityLevel"
 
     versions.collect { v ->
 
@@ -38,15 +67,21 @@ def parseVersions(versions) {
         }
 
         if (v instanceof Map) {
+
+            // Version
             if (!v.containsKey(versionKey)) {
                 throw new Exception("Entry ${v} does not contain ${versionKey}")
             }
+            // Optional
             if (!v.containsKey(optionalKey)) {
                 throw new Exception("Entry ${v} does not contain ${optionalKey}")
             }
-            return new BuildVersion(v[versionKey], v[optionalKey])
+            // API Compatibility Level
+            def apiCompatibilityLevel = v[apiCompatibilityLevelKey]
+
+            return new BuildVersion(v[versionKey], v[optionalKey], apiCompatibilityLevel)
         }
 
-        return new BuildVersion(v.toString(), false)
+        return new BuildVersion(v.toString(), false, null)
     }
 }


### PR DESCRIPTION
- Adds an API compatibility level option to the unity build version arguments; this sets an environment variable to be used by the atlas-unity gradle plugin in order to optionally set an Unity project's API compatibility level.
- Sets --info for each check by default, so that we can read the gradle tasks' logging.

### Tested against skeleton package:

![image](https://user-images.githubusercontent.com/10147802/111463547-fa6b3d00-871f-11eb-8c1b-e290c3ce9381.png)
![image](https://user-images.githubusercontent.com/10147802/111463717-2dadcc00-8720-11eb-8bf4-46ec3858f2e8.png)

## Tested against Core WDK:

**SET TASK:**
![image](https://user-images.githubusercontent.com/10147802/112147910-87f5d380-8bdd-11eb-85b6-3e0f16247866.png)

**UNSET TASK**
![image](https://user-images.githubusercontent.com/10147802/112147975-9643ef80-8bdd-11eb-8181-99a1edb86da4.png)
Where the original values were android : net4_6 (3)
![image](https://user-images.githubusercontent.com/10147802/112147981-9a700d00-8bdd-11eb-8ab4-bac8fcbbdb51.png)



