### PR TITLE
Fix missing scope definition for build version variables

### DIFF
--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -119,8 +119,8 @@ def call(Map config = [unityVersions:[]]) {
                   def environment = []
                   def labels = config.labels
 
-                  version = bv.version
-                  optional = bv.optional
+                  def version = bv.version
+                  def optional = bv.optional
 
                   if(config.testEnvironment) {
                     if(config.testEnvironment instanceof List) {


### PR DESCRIPTION
The optional and version variables were not scoped properly in the check task generator, thus leading to incorrect results from the pipelines.

![image](https://user-images.githubusercontent.com/10147802/111326025-8459ce00-866c-11eb-9d7a-3c58e678b583.png)
