### PR TITLE
Add gradle loglevel params to gradle plugin and java pipeline

### DIFF
--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -11,8 +11,8 @@ import net.wooga.jenkins.pipeline.TestHelper
 
 def call(Map config = [:]) {
   //set config defaults
-  config.platforms = config.plaforms ?: ['osx','windows']
-  config.platforms = config.platforms ?: ['osx','windows']
+  config.platforms = config.plaforms ?: ['macos','windows']
+  config.platforms = config.platforms ?: ['macos','windows']
   config.testEnvironment = config.testEnvironment ?: []
   config.testLabels = config.testLabels ?: []
   config.labels = config.labels ?: ''
@@ -34,8 +34,11 @@ def call(Map config = [:]) {
     }
 
     parameters {
-      choice(choices: "snapshot\nrc\nfinal", description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-       choice(choices: "\npatch\nminor\nmajor", description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+      choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
+      booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
     }
 
     stages {

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -10,148 +10,151 @@ import net.wooga.jenkins.pipeline.TestHelper
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 def call(Map config = [:]) {
-      //set config defaults
-    config.platforms = config.plaforms ?: ['unix']
-    config.platforms = config.platforms ?: ['unix']
-    config.testEnvironment = config.testEnvironment ?: []
-    config.testLabels = config.testLabels ?: []
-    config.labels = config.labels ?: ''
-    config.dockerArgs = config.dockerArgs ?: [:]
-    config.dockerArgs.dockerFileName = config.dockerArgs.dockerFileName ?: "Dockerfile"
-    config.dockerArgs.dockerFileDirectory = config.dockerArgs.dockerFileDirectory ?: "."
-    config.dockerArgs.dockerBuildArgs = config.dockerArgs.dockerBuildArgs ?: []
-    config.dockerArgs.dockerArgs = config.dockerArgs.dockerArgs ?: []
+  //set config defaults
+  config.platforms = config.plaforms ?: ['unix']
+  config.platforms = config.platforms ?: ['unix']
+  config.testEnvironment = config.testEnvironment ?: []
+  config.testLabels = config.testLabels ?: []
+  config.labels = config.labels ?: ''
+  config.dockerArgs = config.dockerArgs ?: [:]
+  config.dockerArgs.dockerFileName = config.dockerArgs.dockerFileName ?: "Dockerfile"
+  config.dockerArgs.dockerFileDirectory = config.dockerArgs.dockerFileDirectory ?: "."
+  config.dockerArgs.dockerBuildArgs = config.dockerArgs.dockerBuildArgs ?: []
+  config.dockerArgs.dockerArgs = config.dockerArgs.dockerArgs ?: []
 
-    def platforms = config.platforms
-    def mainPlatform = platforms[0] == '' ? 'unix' : platforms[0] 
-    def helper = new TestHelper()
+  def platforms = config.platforms
+  def mainPlatform = platforms[0] == '' ? 'unix' : platforms[0] 
+  def helper = new TestHelper()
 
-    pipeline {
-        agent none
+  pipeline {
+    agent none
 
-        options {
-            buildDiscarder(logRotator(artifactNumToKeepStr: '40'))
+    options {
+      buildDiscarder(logRotator(artifactNumToKeepStr: '40'))
+    }
+
+    parameters {
+      choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+      choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
+      booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
+    }
+
+    stages {
+      stage('Preparation') {
+        agent any
+
+        steps {
+          sendSlackNotification "STARTED", true
+        }
+      }
+
+      stage("check") {
+        when {
+          beforeAgent true
+          expression {
+            return params.RELEASE_TYPE == "snapshot"
+          }
         }
 
-        parameters {
-            choice(choices: "snapshot\nrc\nfinal", description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-            choice(choices: "\npatch\nminor\nmajor", description: 'Choose the change scope', name: 'RELEASE_SCOPE')
-        }
+        steps {
+          script {
+            def stepsForParallel = platforms.collectEntries {
+              def environment = []
+              def labels = config.labels
 
-        stages {
-            stage('Preparation') {
-                agent any
-
-                steps {
-                    sendSlackNotification "STARTED", true
+              if (config.testEnvironment) {
+                if (config.testEnvironment instanceof List) {
+                  environment = config.testEnvironment
+                } else {
+                  environment = (config.testEnvironment[it]) ?: []
                 }
+              }
+
+              environment << "COVERALLS_PARALLEL=true"
+
+              if (config.testLabels) {
+                if (config.testLabels instanceof List) {
+                  labels = config.testLabels
+                } else {
+                  labels = (config.testLabels[it]) ?: config.labels
+                }
+              }
+
+              def testConfig = config.clone()
+              testConfig.labels = labels
+
+              def checkStep = { gradleWrapper "check" }
+              def finalizeStep = {
+                if (!currentBuild.result) {
+                  def command = (config.coverallsToken) ? "jacocoTestReport coveralls" : "jacocoTestReport"
+                  withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {
+                    gradleWrapper command
+                    publishHTML([
+                            allowMissing         : true,
+                            alwaysLinkToLastBuild: true,
+                            keepAll              : true,
+                            reportDir            : 'build/reports/jacoco/test/html',
+                            reportFiles          : 'index.html',
+                            reportName           : "Coverage ${it}",
+                            reportTitles         : ''
+                    ])
+                  }
+                }
+                junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
+                cleanWs()
+              }
+
+              ["check ${it}": helper.transformIntoCheckStep(it, environment, config.coverallsToken, testConfig, checkStep, finalizeStep)]
             }
 
-            stage("check") {
-                when {
-                    beforeAgent true
-                    expression {
-                        return params.RELEASE_TYPE == "snapshot"
-                    }
-                }
-
-                steps {
-                    script {
-                        def stepsForParallel = platforms.collectEntries {
-                            def environment = []
-                            def labels = config.labels
-
-                            if (config.testEnvironment) {
-                                if (config.testEnvironment instanceof List) {
-                                    environment = config.testEnvironment
-                                } else {
-                                    environment = (config.testEnvironment[it]) ?: []
-                                }
-                            }
-
-                            environment << "COVERALLS_PARALLEL=true"
-
-                            if (config.testLabels) {
-                                if (config.testLabels instanceof List) {
-                                    labels = config.testLabels
-                                } else {
-                                    labels = (config.testLabels[it]) ?: config.labels
-                                }
-                            }
-
-                            def testConfig = config.clone()
-                            testConfig.labels = labels
-
-                            def checkStep = { gradleWrapper "check" }
-                            def finalizeStep = {
-                                if (!currentBuild.result) {
-                                    def command = (config.coverallsToken) ? "jacocoTestReport coveralls" : "jacocoTestReport"
-                                    withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {
-                                        gradleWrapper command
-                                        publishHTML([
-                                                allowMissing         : true,
-                                                alwaysLinkToLastBuild: true,
-                                                keepAll              : true,
-                                                reportDir            : 'build/reports/jacoco/test/html',
-                                                reportFiles          : 'index.html',
-                                                reportName           : "Coverage ${it}",
-                                                reportTitles         : ''
-                                        ])
-                                    }
-                                }
-                                junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
-                                cleanWs()
-                            }
-
-                            ["check ${it}": helper.transformIntoCheckStep(it, environment, config.coverallsToken, testConfig, checkStep, finalizeStep)]
-                        }
-
-                        parallel stepsForParallel
-                    }
-                }
-
-                post {
-                    success {
-                        httpRequest httpMode: 'POST', ignoreSslErrors: true, url: "https://coveralls.io/webhook?repo_token=${config.coverallsToken}"
-                    }
-                }
-            }
-
-            stage('publish') {
-                agent {
-                    label "$mainPlatform && atlas"
-                }
-
-                environment {
-                    OSSRH = credentials('ossrh.publish')
-                    OSSRH_SIGNING_KEY = credentials('ossrh.signing.key')
-                    OSSRH_SIGNING_KEY_ID = credentials('ossrh.signing.key_id')
-                    OSSRH_SIGNING_PASSPHRASE = credentials('ossrh.signing.passphrase')
-                    OSSRH_USERNAME = "${OSSRH_USR}"
-                    OSSRH_PASSWORD = "${OSSRH_PSW}"
-                    GRGIT = credentials('github_up')
-                    GRGIT_USER = "${GRGIT_USR}"
-                    GRGIT_PASS = "${GRGIT_PSW}"
-                    GITHUB_LOGIN = "${GRGIT_USR}"
-                    GITHUB_PASSWORD = "${GRGIT_PSW}"
-                }
-
-                steps {
-                    gradleWrapper "${params.RELEASE_TYPE.trim()} -Prelease.stage=${params.RELEASE_TYPE.trim()} -Prelease.scope=${params.RELEASE_SCOPE} -x check"
-                }
-
-                post {
-                    cleanup {
-                        cleanWs()
-                    }
-                }
-            }
+            parallel stepsForParallel
+          }
         }
 
         post {
-            always {
-                sendSlackNotification currentBuild.result, true
+            success {
+                httpRequest httpMode: 'POST', ignoreSslErrors: true, url: "https://coveralls.io/webhook?repo_token=${config.coverallsToken}"
             }
         }
+      }
+
+      stage('publish') {
+        agent {
+          label "$mainPlatform && atlas"
+        }
+
+        environment {
+          OSSRH = credentials('ossrh.publish')
+          OSSRH_SIGNING_KEY = credentials('ossrh.signing.key')
+          OSSRH_SIGNING_KEY_ID = credentials('ossrh.signing.key_id')
+          OSSRH_SIGNING_PASSPHRASE = credentials('ossrh.signing.passphrase')
+          OSSRH_USERNAME = "${OSSRH_USR}"
+          OSSRH_PASSWORD = "${OSSRH_PSW}"
+          GRGIT = credentials('github_up')
+          GRGIT_USER = "${GRGIT_USR}"
+          GRGIT_PASS = "${GRGIT_PSW}"
+          GITHUB_LOGIN = "${GRGIT_USR}"
+          GITHUB_PASSWORD = "${GRGIT_PSW}"
+        }
+
+        steps {
+          gradleWrapper "${params.RELEASE_TYPE.trim()} -Prelease.stage=${params.RELEASE_TYPE.trim()} -Prelease.scope=${params.RELEASE_SCOPE} -x check"
+        }
+
+        post {
+          cleanup {
+            cleanWs()
+          }
+        }
+      }
     }
+
+    post {
+      always {
+        sendSlackNotification currentBuild.result, true
+      }
+    }
+  }
 }

--- a/vars/buildPrivateJavaLibrary.groovy
+++ b/vars/buildPrivateJavaLibrary.groovy
@@ -10,8 +10,8 @@ import net.wooga.jenkins.pipeline.TestHelper
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 def call(Map config = [:]) {
-  config.platforms = config.plaforms ?: ['osx','windows']
-  config.platforms = config.platforms ?: ['osx','windows']
+  config.platforms = config.plaforms ?: ['unix']
+  config.platforms = config.platforms ?: ['unix']
   config.testEnvironment = config.testEnvironment ?: []
   config.testLabels = config.testLabels ?: []
   config.labels = config.labels ?: ''
@@ -33,8 +33,11 @@ def call(Map config = [:]) {
     }
 
     parameters {
-      choice(choices: "snapshot\nrc\nfinal", description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-       choice(choices: "\npatch\nminor\nmajor", description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+      choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
+      booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
     }
 
     stages {

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -46,11 +46,11 @@ def call(Map config = [ unityVersions:[] ]) {
     }
 
     parameters {
-        choice(choices: "snapshot\nrc\nfinal", description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-        choice(choices: "\npatch\nminor\nmajor", description: 'Choose the change scope', name: 'RELEASE_SCOPE')
-        choice(choices: "\ninfo\nwarn\nquiet\ndebug", description: 'Choose the log level', name: 'LOG_LEVEL')
-        booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
-        booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
+      choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+      choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
+      booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
     }
 
     stages {


### PR DESCRIPTION
## Description

This patch adds and reformats missing pipeline parameter for gradle. I also reformated the buildJavaLibraryOSSRH file as it used the wrong indentation size. I also updated the choice parameter format. Jenkins support arrays for quite some time now which makes this look cleaner than the newline delimited string values.

## Changes

* ![IMPROVE] missing loglevel params for gradle and java pipelines
* ![IMPROVE] file formatting of `buildJavaLibraryOSSRH`
* ![IMPROVE] choice parameter format

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"