### PR TITLE
Fix the default of LOG_LEVEL being set to quiet; default of RELEASE_SCOPE

### DIFF
--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -35,8 +35,8 @@ def call(Map config = [:]) {
 
     parameters {
       choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-      choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
-      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      choice(choices: ["", "patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
     }

--- a/vars/buildJavaLibrary.groovy
+++ b/vars/buildJavaLibrary.groovy
@@ -34,8 +34,8 @@ def call(Map config = [:]) {
     }
 
     parameters {
-      choice(choices: "snapshot\nrc\nfinal", description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-       choice(choices: "\npatch\nminor\nmajor", description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+      choice(choices: ["", "patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
     }
 
     stages {

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -35,8 +35,8 @@ def call(Map config = [:]) {
 
     parameters {
       choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-      choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
-      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      choice(choices: ["", "patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
     }

--- a/vars/buildPrivateJavaLibrary.groovy
+++ b/vars/buildPrivateJavaLibrary.groovy
@@ -35,7 +35,7 @@ def call(Map config = [:]) {
     parameters {
       choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
       choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
-      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
     }

--- a/vars/buildWDK.groovy
+++ b/vars/buildWDK.groovy
@@ -41,8 +41,8 @@ def call(Map config = [unityVersions:[]]) {
     }
 
     parameters {
-        choice(choices: "snapshot\nrc\nfinal", description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-        choice(choices: "\npatch\nminor\nmajor", description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+      choice(choices: ["", "patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
     }
 
     stages {

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -47,8 +47,8 @@ def call(Map config = [ unityVersions:[] ]) {
 
     parameters {
       choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
-      choice(choices: ["patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
-      choice(choices: ["quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
+      choice(choices: ["", "patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
+      choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
     }


### PR DESCRIPTION
Sets the default value to empty for LOG_LEVEL, RELEASE_SCOPE.
Previously both were always set to the first element in the choice array, overriding defaults needlessly.