### PR TITLE
Fix the iterator for testEnvironment and label lookup

### DIFF
--- a/src/net/wooga/jenkins/pipeline/BuildUtils.groovy
+++ b/src/net/wooga/jenkins/pipeline/BuildUtils.groovy
@@ -61,6 +61,9 @@ def parseVersions(versions) {
     final apiCompatibilityLevelKey = "apiCompatibilityLevel"
 
     versions.collect { v ->
+        if (v instanceof BuildVersion) {
+            return v
+        }
 
         if (v instanceof Closure) {
             v = v.call()

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -142,7 +142,7 @@ def call(Map config = [ unityVersions:[] ]) {
                       environment.addAll(config.testEnvironment)
                     }
                     else {
-                      environment.addAll( (config.testEnvironment[it]) ?: [])
+                      environment.addAll( (config.testEnvironment[bv]) ?: [])
                     }
                   }
 
@@ -151,7 +151,7 @@ def call(Map config = [ unityVersions:[] ]) {
                       labels = config.testLabels
                     }
                     else {
-                      labels = (config.testLabels[it]) ?: config.labels
+                      labels = (config.testLabels[bv]) ?: config.labels
                     }
                   }
 


### PR DESCRIPTION
Since we gave the iterator an explicit name the map version of testEnvironment and label lookup was not working anymore.
Also since the index is now an object reference rather than a string it would make sense to refactor that part a bit. Maybe move the environment additions into the BuildVersion model?