### PR TITLE
 java lib ossrh no snapshots by default

### DIFF
--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -34,7 +34,7 @@ def call(Map config = [:]) {
     }
 
     parameters {
-      choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
+      choice(choices: ["", "snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
       choice(choices: ["", "patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')
       choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
@@ -123,6 +123,10 @@ def call(Map config = [:]) {
       stage('publish') {
         agent {
           label "$mainPlatform && atlas"
+        }
+
+        when {
+          expression { params.RELEASE_TYPE.trim() != "" }
         }
 
         environment {

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -54,7 +54,7 @@ def call(Map config = [:]) {
         when {
           beforeAgent true
           expression {
-            return params.RELEASE_TYPE == "snapshot"
+            return params.RELEASE_TYPE in ["snapshot", ""]
           }
         }
 


### PR DESCRIPTION
This fixes the issue where a java OSS library would try to run the snapshot task by default. 
The default for the release-stage field will be empty; if it's empty we skip the publishTask.