### PR TITLE
Sonarqube now only executes in master/main branch

### DIFF
--- a/test/groovy/specs/BuildGradlePluginSpec.groovy
+++ b/test/groovy/specs/BuildGradlePluginSpec.groovy
@@ -11,20 +11,42 @@ class BuildGradlePluginSpec extends DeclarativeJenkinsSpec {
 
     def setupSpec() {
         binding.setVariable("params", [RELEASE_TYPE: "snapshot"])
+        helper.registerAllowedMethod("isUnix") { true }
         this.gradleWrapperScript = helper.loadScript("vars/gradleWrapper.groovy", binding)
+        helper.registerAllowedMethod("gradleWrapper", [String]) { command ->
+            this.gradleWrapperScript.call(command)
+        }
+    }
+
+    def "should post coveralls results to coveralls server" () {
+        given: "loaded buildGradlePlugin in a successful build"
+        helper.registerAllowedMethod("httpRequest", [LinkedHashMap]) {}
+        def buildGradlePlugin = loadScript("vars/buildGradlePlugin.groovy") {
+            currentBuild["result"] = "SUCCESS"
+        }
+
+        and: "a coveralls token"
+        def coverallsToken = "token"
+
+        when: "running gradle pipeline with coverallsToken parameter"
+        buildGradlePlugin(coverallsToken: coverallsToken)
+
+        then: "request is sent to coveralls webhook"
+        hasMethodCallWith("httpRequest"){ MethodCall call ->
+            Map params = call.args[0] as Map
+            return params["httpMode"] == "POST" &&
+                    params["ignoreSslErrors"] == true &&
+                    params["url"] == "https://coveralls.io/webhook?repo_token=${coverallsToken}"
+        }
     }
 
     @Unroll("should execute #name if their token(s) are present")
     def "should execute coverage when its token is present" (){
-        given: "loaded buildGradlePlugin in a running build"
-        binding.getVariable("currentBuild").with { result = null }
-        helper.registerAllowedMethod("gradleWrapper", [String]) { command ->
-            this.gradleWrapperScript.call(command)
+        given: "loaded buildGradlePlugin in a running build in the master branch"
+        def buildGradlePlugin = loadScript("vars/buildGradlePlugin.groovy") {
+            BRANCH_NAME = "master"
+            currentBuild["result"] = null
         }
-        def buildGradlePlugin = helper.loadScript("vars/buildGradlePlugin.groovy", binding)
-
-        and: "a unix-like platform"
-        helper.registerAllowedMethod("isUnix") {true}
 
         when: "running gradle pipeline with coverage token"
         buildGradlePlugin(sonarToken: sonarToken, coverallsToken: coverallsToken)
@@ -42,30 +64,41 @@ class BuildGradlePluginSpec extends DeclarativeJenkinsSpec {
         "SonarQube & Coveralls" | ["coveralls", "sonarqube", "-Dsonar.login=sonarToken"]   |"sonarToken"  | "coverallsToken"
     }
 
-    def "should post coveralls results to coveralls server" () {
-        given: "loaded buildGradlePlugin in a successful build"
-        binding.getVariable("currentBuild").with { result = "SUCCESS" }
-        helper.registerAllowedMethod("httpRequest", [LinkedHashMap]) {}
-        helper.registerAllowedMethod("gradleWrapper", [String]) { command ->
-            this.gradleWrapperScript.call(command)
+    @Unroll("#shouldRunSonar execute sonarqube if #branchName matches pattern when RUN_SONAR is #runSonarParam")
+    def "should only execute sonarqube in branches matching pattern unless RUN_SONAR is true" () {
+        given: "loaded build script in a running build in the ${branchName} branch"
+        def buildGradlePlugin = loadScript("vars/buildGradlePlugin.groovy") {
+            BRANCH_NAME = branchName
+            currentBuild["result"] = null
         }
-        def buildGradlePlugin = helper.loadScript("vars/buildGradlePlugin.groovy", binding)
 
-        and: "a coveralls token"
-        def coverallsToken = "token"
+        and: "RUN_SONAR set to ${runSonarParam}"
+        binding.getVariable("params").with { RUN_SONAR = runSonarParam }
 
-        and: "a unix-like platform"
-        helper.registerAllowedMethod("isUnix") {true}
+        and: "sonarQubeBranchPattern config set to ${branchPattern?: "default (^main|master\$)"}"
+        def runConfig = [sonarToken: "sonarToken", sonarQubeBranchPattern: branchPattern]
 
-        when: "running gradle pipeline with coverallsToken parameter"
-        buildGradlePlugin(coverallsToken: coverallsToken)
+        when: "running gradle pipeline with sonar token"
+        buildGradlePlugin(runConfig)
 
-        then: "request is sent to coveralls webhook"
-        hasMethodCallWith("httpRequest"){ MethodCall call ->
-            Map params = call.args[0] as Map
-            return params["httpMode"] == "POST" &&
-                    params["ignoreSslErrors"] == true &&
-                    params["url"] == "https://coveralls.io/webhook?repo_token=${coverallsToken}"
+        then: "${shouldRunSonar} run sonar analysis"
+        def sonarCalled = hasShCallWith { callString ->
+            callString.contains("gradlew") &&
+                    callString.contains("sonarqube") &&
+                    callString.contains("-Dsonar.login=sonarToken")
         }
+        shouldRunSonar == "should"? sonarCalled : !sonarCalled
+
+        where:
+        branchName              | branchPattern | runSonarParam | shouldRunSonar
+        "master"                | null          | true          | "should"
+        "master"                | null          | false         | "should"
+        "master"                | "^nomaster\$" | false         | "shouldn't"
+        "main"                  | null          | true          | "should"
+        "main"                  | null          | false         | "should"
+        "main"                  | "^nomaster\$" | false         | "shouldn't"
+        "nomaster"              | null          | true          | "should"
+        "nomaster"              | "^nomaster\$" | false         | "should"
+        "nomaster"              | null          | false         | "shouldn't"
     }
 }

--- a/test/groovy/tools/DeclarativeJenkinsSpec.groovy
+++ b/test/groovy/tools/DeclarativeJenkinsSpec.groovy
@@ -16,7 +16,7 @@ abstract class DeclarativeJenkinsSpec extends Specification {
     @Shared Binding binding
     @Shared PipelineTestHelper helper
 
-    public void setupSpec() {
+    def setupSpec() {
         jenkinsTest = new DeclarativePipelineTest() {}
         jenkinsTest.setUp()
         helper = jenkinsTest.helper
@@ -27,6 +27,10 @@ abstract class DeclarativeJenkinsSpec extends Specification {
         populateJenkinsDefaultEnvironment(binding)
         registerPipelineFakeMethods(helper)
         forceMockedScriptConstructor(binding, helper, TestHelper.metaClass, "src/net/wooga/jenkins/pipeline/TestHelper.groovy")
+    }
+
+    def cleanup() {
+       helper?.callStack?.clear()
     }
 
     private static void populateJenkinsDefaultEnvironment(Binding binding) {
@@ -70,5 +74,11 @@ abstract class DeclarativeJenkinsSpec extends Specification {
         return helper.callStack.findAll { call ->
             call.methodName == methodName
         }.any(assertion)
+    }
+
+    protected Script loadScript(String name, Closure varBindingOps) {
+        varBindingOps.setDelegate(binding.variables)
+        varBindingOps(binding.variables)
+        return helper.loadScript(name, binding)
     }
 }

--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -16,6 +16,7 @@ def call(Map config = [:]) {
   config.testEnvironment = config.testEnvironment ?: []
   config.testLabels = config.testLabels ?: []
   config.labels = config.labels ?: ''
+  config.sonarQubeBranchPattern = config.sonarQubeBranchPattern ?: "^(master|main)\$"
   config.dockerArgs = config.dockerArgs ?: [:]
   config.dockerArgs.dockerFileName = config.dockerArgs.dockerFileName ?: "Dockerfile"
   config.dockerArgs.dockerFileDirectory = config.dockerArgs.dockerFileDirectory ?: "."
@@ -39,6 +40,7 @@ def call(Map config = [:]) {
       choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
+      booleanParam(defaultValue: false, description: 'Whether to force sonarqube execution', name: 'RUN_SONAR')
     }
 
     stages {
@@ -96,7 +98,7 @@ def call(Map config = [:]) {
                   if (config.coverallsToken) {
                     tasks += " coveralls"
                   }
-                  if(config.sonarToken) {
+                  if(config.sonarToken && (BRANCH_NAME =~ config.sonarQubeBranchPattern || params.RUN_SONAR)) {
                     tasks += " sonarqube -Dsonar.login=${config.sonarToken}"
                   }
                   withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {


### PR DESCRIPTION
SonarQube execution is now restricted to the `main` or `master` branches. If you still wish to execute sonar in another branch, this condition can be overwritten by setting the RUN_SONAR parameter to true.

