### PR TITLE
Improve Java OSSRH pipeline with sonarqube publish and optional ws clean

### DIFF
--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -40,6 +40,7 @@ def call(Map config = [:]) {
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
       booleanParam(defaultValue: false, description: 'Whether to force sonarqube execution', name: 'RUN_SONAR')
+      booleanParam(defaultValue: true, description: 'Whether to clean the workspace after the build', name: 'CLEAN_WORKSPACE')
     }
 
     stages {
@@ -114,7 +115,9 @@ def call(Map config = [:]) {
                   }
                 }
                 junit allowEmptyResults: true, testResults: "**/build/test-results/**/*.xml"
-                cleanWs()
+                if(params.CLEAN_WORKSPACE) {
+                  cleanWs()
+                }
               }
 
               ["check ${platform}" : helper.transformIntoCheckStep(platform, environment, config.coverallsToken, testConfig, checkStep, finalizeStep)]
@@ -164,7 +167,11 @@ def call(Map config = [:]) {
 
         post {
           cleanup {
-            cleanWs()
+            scrips {
+              if(params.CLEAN_WORKSPACE) {
+                cleanWs()
+              }
+            }
           }
         }
       }

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -51,6 +51,7 @@ def call(Map config = [ unityVersions:[] ]) {
       choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
+      booleanParam(defaultValue: true, description: 'Whether to clean the workspace after the build', name: 'CLEAN_WORKSPACE')
     }
 
     stages {
@@ -80,7 +81,11 @@ def call(Map config = [ unityVersions:[] ]) {
           }
 
           cleanup {
-            cleanWs()
+            script {
+              if(params.CLEAN_WORKSPACE) {
+                cleanWs()
+              }
+            }
           }
         }
       }
@@ -115,7 +120,11 @@ def call(Map config = [ unityVersions:[] ]) {
               }
 
               cleanup {
-                cleanWs()
+                script {
+                  if(params.CLEAN_WORKSPACE) {
+                    cleanWs()
+                  }
+                }
               }
             }
           }
@@ -188,7 +197,10 @@ def call(Map config = [ unityVersions:[] ]) {
                     dir (directoryName) {
                       deleteDir()
                     }
-                    cleanWs()
+
+                    if(params.CLEAN_WORKSPACE) {
+                      cleanWs()
+                    }
                   }
 
                   def Map args = [:]
@@ -238,7 +250,11 @@ def call(Map config = [ unityVersions:[] ]) {
           }
 
           cleanup {
-            cleanWs()
+            script {
+              if(params.CLEAN_WORKSPACE) {
+                cleanWs()
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

This patch adds some improvements and fixes from the build gradle plugin pipeline. I fixed the default values for platform in the same way we fixed it for buildGradlePlugin in commit d88125bc. I also copied the setup for the sonarqube publish. As a last improvement I also added a new parameter `CLEAN_WORKSPACE` for both `buildGradlePlugin`, buildJavaLibraryOSSRH` and `buildWDKAutoSwitch`

The idea is to make the cleanup controlable during invocation of the pipeline. The default value is `true`.

Changes
=======

* ![FIX] `config.platform` default value lookup
* ![ADD] sonarqube publish setup in `buildJavaLibraryOSSRH`
* ![IMPROVE] cleanup workspace with pipeline parameter

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"