### PR TITLE
Inject signing credentials into private java libraries pipeline [ATLAS-151]

### DIFF
--- a/vars/buildPrivateJavaLibrary.groovy
+++ b/vars/buildPrivateJavaLibrary.groovy
@@ -127,15 +127,19 @@ def call(Map config = [:]) {
         }
 
         environment {
-          ARTIFACTORY           = credentials('artifactory_publish')
-          GRGIT                 = credentials('github_up')
+          ARTIFACTORY               = credentials('artifactory_publish')
+          GRGIT                     = credentials('github_up')
 
-          ARTIFACTORY_USER      = "${ARTIFACTORY_USR}"
-          ARTIFACTORY_PASS      = "${ARTIFACTORY_PSW}"
-          GRGIT_USER            = "${GRGIT_USR}"
-          GRGIT_PASS            = "${GRGIT_PSW}"
-          GITHUB_LOGIN          = "${GRGIT_USR}"
-          GITHUB_PASSWORD       = "${GRGIT_PSW}"
+          OSSRH_SIGNING_KEY         = credentials('ossrh.signing.key')
+          OSSRH_SIGNING_KEY_ID      = credentials('ossrh.signing.key_id')
+          OSSRH_SIGNING_PASSPHRASE  = credentials('ossrh.signing.passphrase')
+
+          ARTIFACTORY_USER          = "${ARTIFACTORY_USR}"
+          ARTIFACTORY_PASS          = "${ARTIFACTORY_PSW}"
+          GRGIT_USER                = "${GRGIT_USR}"
+          GRGIT_PASS                = "${GRGIT_PSW}"
+          GITHUB_LOGIN              = "${GRGIT_USR}"
+          GITHUB_PASSWORD           = "${GRGIT_PSW}"
         }
 
         steps {


### PR DESCRIPTION
## Description

I want to make the process of build open source and closed source libraries as similar as possible. I decided to also code sign our private libs so the build.gradle filewouldn't need much changes if we decide to move a lib from close to open or vice versa.

## Changes

* ![IMPROVE] inject signing credentials into private lib pipeline


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
