### PR TITLE
Change the WDK NUnit `testResultsPattern` to look only into `unity/test*` directories

### DIFF
--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -181,7 +181,7 @@ def call(Map config = [ unityVersions:[] ]) {
                   }
 
                   def finalizeStep = {
-                    nunit failIfNoResults: false, testResultsPattern: '**/build/reports/unity/**/*.xml'
+                    nunit failIfNoResults: false, testResultsPattern: '**/build/reports/unity/test*/*.xml'
                     archiveArtifacts artifacts: '**/build/logs/**/*.log', allowEmptyArchive: true
                     archiveArtifacts artifacts: '**/build/reports/unity/**/*.xml' , allowEmptyArchive: true
                     publishCoverage adapters: [istanbulCoberturaAdapter('**/codeCoverage/Cobertura.xml')], sourceFileResolver: sourceFiles('STORE_LAST_BUILD')


### PR DESCRIPTION
## Description
Tighten the WDK NUnit `testResultsPattern` to not clash with other reports in `build/reports/unity` (e.g. code coverage)

JIRA Ticket [ATLAS-207](https://woogagmbh.atlassian.net/browse/ATLAS-207)
[Test run with wdk-unity-Tracking](https://jenkins.atlas.wooga.com/job/wdk_unity/job/wdk-unity-Tracking/view/change-requests/job/PR-87/2/)

## Changes
* ![CHANGE] WDK testResultsPattern from `'**/build/reports/unity/**/*.xml'` to `'**/build/reports/unity/test*/*.xml'`


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
