### PR TITLE
Fix local integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,10 +38,6 @@ pipeline {
     agent any
     stages {
         stage("Check") {
-            environment {
-                GRGIT_USER = "${ATLAS_GITHUB_INTEGRATION_USR}"
-                GRGIT_PASS = "${ATLAS_GITHUB_INTEGRATION_PSW}"
-            }
             steps { gradleWrapper "check" }
             post {
                 always {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,9 +17,10 @@ dependencies {
     implementation 'org.ajoberstar.grgit:grgit-core:[4,5)'
     implementation 'org.codehaus.groovy:groovy-all:2.5.12'
     implementation gradleApi()
+    testImplementation 'com.github.stefanbirkner:system-rules:[1,2)'
     testImplementation platform("org.spockframework:spock-bom:1.2-groovy-2.4")
     testImplementation "org.spockframework:spock-core"
-    testImplementation 'com.wooga.spock.extensions:spock-github-extension:0.1.2'
+    testImplementation 'com.wooga.spock.extensions:spock-github-extension:0.2.0'
     testImplementation ('com.netflix.nebula:nebula-test:[8,9)') {
         version {
             strictly '8.1.0'

--- a/buildSrc/src/test/groovy/integration/VersionPluginIntegrationSpec.groovy
+++ b/buildSrc/src/test/groovy/integration/VersionPluginIntegrationSpec.groovy
@@ -1,6 +1,5 @@
 package integration
 
-
 import com.wooga.jenkins.VersionTask
 import com.wooga.spock.extensions.github.GithubRepository
 import com.wooga.spock.extensions.github.Repository
@@ -10,13 +9,17 @@ import nebula.test.IntegrationSpec
 import org.ajoberstar.grgit.Credentials
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Tag
-import org.apache.commons.lang3.RandomStringUtils
-import spock.lang.Unroll;
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import spock.lang.Unroll
 
 class VersionPluginIntegrationSpec extends IntegrationSpec {
 
+    @Rule
+    EnvironmentVariables environment = new EnvironmentVariables()
+
     @GithubRepository(
-            repositoryNamePrefix = "pipeline-buildsrc",
+            repositoryNamePrefix = "atlas-jenkins-pipeline-integrationSpec",
             usernameEnv = "ATLAS_GITHUB_INTEGRATION_USER",
             tokenEnv = "ATLAS_GITHUB_INTEGRATION_PASSWORD",
             repositoryPostFixProvider = [TravisBuildNumberPostFix.class],
@@ -49,6 +52,10 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
             remote = "origin"
             updateType = "${updateType}"
         }"""
+
+        and: "credentials in the environment"
+        environment.set("GRGIT_USER", this.githubRepo.userName)
+        environment.set("GRGIT_PASS", this.githubRepo.token)
 
         when:
         runTasksSuccessfully(VersionTask.TASK_NAME)
@@ -85,7 +92,7 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
 
     def initializeGrGit(String remote) {
         Grgit git = Grgit.init(dir: projectDir)
-        git.remote.add(name: remote, url: this.githubRepo.gitHttpTransportUrl())
+        git.remote.add(name: remote, url: this.githubRepo.httpTransportUrl)
         git.close()
 
         git = Grgit.open(dir: projectDir, credentials: new Credentials(this.githubRepo.userName, this.githubRepo.token))


### PR DESCRIPTION
## Description

This patch sets the grgit credentials needed to run the tests locally before the tests are executed. On jenkins it is done withing the pipeline which was actually not needed.

There was also an invocation to `gitHttpTransportUrl` which is both a getter and a method. But it seems that in a newer version of the github API the method is gone.

## Changes

* ![FIX] local integration tests.


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
