### PR TITLE
Remove sonarqube branch limitation and added branch name property

### DIFF
--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -15,7 +15,6 @@ def call(Map config = [:]) {
   config.testEnvironment = config.testEnvironment ?: []
   config.testLabels = config.testLabels ?: []
   config.labels = config.labels ?: ''
-  config.sonarQubeBranchPattern = config.sonarQubeBranchPattern ?: "^(master|main)\$"
   config.dockerArgs = config.dockerArgs ?: [:]
   config.dockerArgs.dockerFileName = config.dockerArgs.dockerFileName ?: "Dockerfile"
   config.dockerArgs.dockerFileDirectory = config.dockerArgs.dockerFileDirectory ?: "."
@@ -97,7 +96,7 @@ def call(Map config = [:]) {
                   if (config.coverallsToken) {
                     tasks += " coveralls"
                   }
-                  if(config.sonarToken && (BRANCH_NAME =~ config.sonarQubeBranchPattern || params.RUN_SONAR)) {
+                  if(config.sonarToken || params.RUN_SONAR) {
                     tasks += " sonarqube -Dsonar.login=${config.sonarToken}"
                   }
                   withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {

--- a/vars/buildJavaLibrary.groovy
+++ b/vars/buildJavaLibrary.groovy
@@ -87,7 +87,12 @@ def call(Map config = [:]) {
               def checkStep = { gradleWrapper "check" }
               def finalizeStep = {
                 if(!currentBuild.result) {
-                  def command = (config.coverallsToken) ? "jacocoTestReport coveralls" : "jacocoTestReport"
+                  if (config.coverallsToken) {
+                    tasks += " coveralls"
+                  }
+                  if(config.sonarToken) {
+                    tasks += " sonarqube -Dsonar.login=${config.sonarToken}"
+                  }
                   withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {
                     gradleWrapper command
                     publishHTML([

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -88,7 +88,12 @@ def call(Map config = [:]) {
               def checkStep = { gradleWrapper "check" }
               def finalizeStep = {
                 if (!currentBuild.result) {
-                  def command = (config.coverallsToken) ? "jacocoTestReport coveralls" : "jacocoTestReport"
+                  if (config.coverallsToken) {
+                    tasks += " coveralls"
+                  }
+                  if(config.sonarToken) {
+                    tasks += " sonarqube -Dsonar.login=${config.sonarToken}"
+                  }
                   withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {
                     gradleWrapper command
                     publishHTML([

--- a/vars/buildPrivateJavaLibrary.groovy
+++ b/vars/buildPrivateJavaLibrary.groovy
@@ -89,7 +89,12 @@ def call(Map config = [:]) {
               def checkStep = { gradleWrapper "check" }
               def finalizeStep = {
                 if(!currentBuild.result) {
-                  def command = (config.coverallsToken) ? "jacocoTestReport coveralls" : "jacocoTestReport"
+                  if (config.coverallsToken) {
+                    tasks += " coveralls"
+                  }
+                  if(config.sonarToken) {
+                    tasks += " sonarqube -Dsonar.login=${config.sonarToken}"
+                  }
                   withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {
                     gradleWrapper command
                     publishHTML([

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -168,6 +168,9 @@ def call(Map config = [ unityVersions:[] ]) {
                       checkout scm
                       unstash 'setup_w'
                       gradleWrapper "-Prelease.stage=${params.RELEASE_TYPE.trim()} -Prelease.scope=${params.RELEASE_SCOPE} check"
+                      if(config.sonarToken) {
+                        gradleWrapper "sonarqube -Dsonar.login=${config.sonarToken}"
+                      }
                     }
                   }
 


### PR DESCRIPTION
## Description
Sonarqube will now execute for all branches, in order to provider PR information to sonarqube. Sonarqube differentiates between PR analysis and plain branch analysis, and give precedence to later. So, if the branch property is set, sonarqube will run the analysis as plain branch one.  

Thus, we force this property to empty on PR analysis in order to sonarqube to detect this run as a PR analysis. On non-PR runs, the branch name property is set to `$BRANCH_NAME`.

PS: right now, this is only working 100% for the `buildGradlePlugin` pipeline. Other pipelines gradle plugins does not support the sonarqube task yet, so please do not enable sonarqube coverage by setting a value to `config.sonarToken` until support is provided.

## Changes
* ![REMOVE] branch name should be master or main in order for sonarqube to execute
* ![ADD] branch name property to gradle sonarqube task execution 

[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
