### PR TITLE
Added sonarqube call for all non-deprecated pipelines

### DIFF
--- a/src/net/wooga/jenkins/pipeline/check/Checks.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/Checks.groovy
@@ -33,13 +33,14 @@ class Checks {
         this.coveralls = commands.coveralls
     }
 
-    Map<String, Closure> javaCoverage(Config config, boolean isPR) {
+    Map<String, Closure> javaCoverage(Config config) {
         return checkCreator.javaChecks(config.platforms, {
                 jenkins.checkout(jenkins.scm)
                 gradle.wrapper("check")
             }, {
+                def branchName = config.metadata.isPR()? null : config.metadata.branchName
                 gradle.wrapper("jacocoTestReport")
-                sonarqube.runGradle(gradle, config.sonarArgs, isPR? null : config.metadata.branchName)
+                sonarqube.runGradle(gradle, config.sonarArgs, branchName)
                 coveralls.runGradle(gradle, config.coverallsToken)
             })
     }
@@ -62,6 +63,8 @@ class Checks {
                         "check")
             }
         },{
+            def branchName = config.metadata.isPR()? null : config.metadata.branchName
+            sonarqube.runGradle(gradle, config.sonarArgs, branchName)
             def coberturaAdapter = jenkins.istanbulCoberturaAdapter('**/codeCoverage/Cobertura.xml')
             jenkins.publishCoverage adapters: [coberturaAdapter],
                                     sourceFileResolver: jenkins.sourceFiles('STORE_LAST_BUILD')

--- a/src/net/wooga/jenkins/pipeline/config/JenkinsMetadata.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/JenkinsMetadata.groovy
@@ -4,17 +4,27 @@ class JenkinsMetadata {
 
     final int buildNumber
     final String branchName
+    final String prChangeId
 
     static JenkinsMetadata fromScript(Object jenkinsScript) {
+        if(jenkinsScript.BUILD_NUMBER == null) {
+            throw new IllegalStateException("Jenkins script object must have a BUILD_NUMBER property")
+        }
         return new JenkinsMetadata(
                 jenkinsScript.BUILD_NUMBER as int,
-                jenkinsScript.BRANCH_NAME as String
+                jenkinsScript.BRANCH_NAME as String,
+                jenkinsScript.env?.getAt("CHANGE_ID") as String //nullable
         )
     }
 
-    JenkinsMetadata(int buildNumber, String branchName) {
+    JenkinsMetadata(int buildNumber, String branchName, String prChangeId) {
+        this.prChangeId = prChangeId
         this.buildNumber = buildNumber
         this.branchName = branchName
+    }
+
+    boolean isPR() {
+        return prChangeId != null
     }
 
     boolean equals(o) {

--- a/src/net/wooga/jenkins/pipeline/config/WDKConfig.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/WDKConfig.groovy
@@ -4,28 +4,35 @@ import net.wooga.jenkins.pipeline.BuildVersion
 
 class WDKConfig {
 
-    static WDKConfig fromConfigMap(String buildLabel, Map configMap) {
-        configMap.unityVersions = configMap.unityVersions?: []
+    static WDKConfig fromConfigMap(String buildLabel, Map configMap, Object jenkinsScript) {
+        configMap.unityVersions = configMap.unityVersions ?: []
         def unityVersions = configMap.unityVersions.collect { unityVersionObj ->
             def buildVersion = BuildVersion.parse(unityVersionObj)
             def platform = Platform.forWDK(buildVersion, buildLabel, configMap)
             return new UnityVersionPlatform(platform, buildVersion)
         }
-        if(unityVersions.isEmpty()) throw new IllegalArgumentException("Please provide at least one unity version.")
+        if (unityVersions.isEmpty()) throw new IllegalArgumentException("Please provide at least one unity version.")
 
+        def sonarArgs = SonarQubeArgs.fromConfigMap(configMap)
+        def jenkinsMetadata = JenkinsMetadata.fromScript(jenkinsScript)
         boolean refreshDependencies = configMap.refreshDependencies ?: false
         String logLevel = configMap.logLevel ?: ''
 
-        return new WDKConfig(unityVersions, refreshDependencies, logLevel, buildLabel)
+        return new WDKConfig(unityVersions, sonarArgs, jenkinsMetadata, refreshDependencies, logLevel, buildLabel)
     }
 
     final UnityVersionPlatform[] unityVersions
+    final SonarQubeArgs sonarArgs
+    final JenkinsMetadata metadata
     final boolean refreshDependencies
     final String logLevel
     final String buildLabel
 
-    WDKConfig(List<UnityVersionPlatform> unityVersions, boolean refreshDependencies, String logLevel, String buildLabel) {
+    WDKConfig(List<UnityVersionPlatform> unityVersions, SonarQubeArgs sonarArgs, JenkinsMetadata metadata,
+              boolean refreshDependencies, String logLevel, String buildLabel) {
         this.unityVersions = unityVersions
+        this.sonarArgs = sonarArgs
+        this.metadata = metadata
         this.refreshDependencies = refreshDependencies
         this.logLevel = logLevel
         this.buildLabel = buildLabel

--- a/test/groovy/net/wooga/jenkins/pipeline/config/JenkinsMetadataSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/JenkinsMetadataSpec.groovy
@@ -1,0 +1,38 @@
+package net.wooga.jenkins.pipeline.config
+
+import spock.lang.Specification
+
+class JenkinsMetadataSpec extends Specification {
+
+    def "creates jenkins metadata object from object with jenkins script properties"() {
+        given: "a object with jenkins script properties"
+        def propsObj = [BUILD_NUMBER: buildNumber, BRANCH_NAME: branchName, env:[CHANGE_ID: prChangeId]]
+
+        when:
+        def metadata = JenkinsMetadata.fromScript(propsObj)
+
+        then:
+        metadata.buildNumber == buildNumber
+        metadata.branchName == branchName
+        metadata.prChangeId == prChangeId
+        metadata.isPR() == (prChangeId != null)
+
+        where:
+        buildNumber | branchName | prChangeId
+        1           | "branch"   | "123"
+        1           | "branch"   | null
+    }
+
+    def "fails to jenkins metadata object if buildNumber does not exists"() {
+        given: "a object with jenkins script properties without BUILD_NUMBER"
+        def propsObj = [BRANCH_NAME: "branch", env:[CHANGE_ID: "change"]]
+
+        when:
+        JenkinsMetadata.fromScript(propsObj)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Jenkins script object must have a BUILD_NUMBER property"
+    }
+
+}

--- a/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
@@ -1,43 +1,58 @@
 package net.wooga.jenkins.pipeline.config
 
 import net.wooga.jenkins.pipeline.BuildVersion
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class WDKConfigSpec extends Specification {
+
+    @Shared
+    def jenkinsScript = [BUILD_NUMBER: 1, BRANCH_NAME: "branch"]
+
 
     @Unroll("creates valid WDKConfig object from #configMap")
     def "creates valid WDKConfig object from config map"() {
         given: "a configuration map"
         and: "a jenkins build label"
         when:
-        def wdkConf = WDKConfig.fromConfigMap(label, configMap)
+        def wdkConf = WDKConfig.fromConfigMap(label, configMap, jenkinsScript)
         then:
         wdkConf.unityVersions == expected.unityVersions
         wdkConf.buildLabel == expected.buildLabel
+        wdkConf.sonarArgs == expected.sonarArgs
+        wdkConf.metadata == expected.metadata
         wdkConf.refreshDependencies == expected.refreshDependencies
         wdkConf.logLevel == expected.logLevel
 
         where:
-        configMap                                                                | label | expected
-        [unityVersions: ["2019", "2020"]]                                        | "l"   | new WDKConfig(platsFor(["2019", "2020"], "l"), false, "", "l")
-        [unityVersions: ["2019"], refreshDependencies: true]                     | "p"   | new WDKConfig(platsFor(["2019"], "p"), true, "", "p")
-        [unityVersions: ["2019"], logLevel: "level"]                             | "o"   | new WDKConfig(platsFor(["2019"], "o"), false, "level", "o")
-        [unityVersions: ["2019"], refreshDependencies: true, logLevel: "level"]  | "l"   | new WDKConfig(platsFor(["2019"], "l"), true, "level", "l")
-        [unityVersions: ["2019"], refreshDependencies: false, logLevel: "level"] | "l"   | new WDKConfig(platsFor(["2019"], "l"), false, "level", "l")
+        configMap                                                                                     | label | expected
+        [unityVersions: ["2019", "2020"]]                                                             | "l"   | configFor(["2019", "2020"], "l", null, false, "")
+        [unityVersions: ["2019"], refreshDependencies: true]                                          | "p"   | configFor(["2019"], "p", null, true, "")
+        [unityVersions: ["2019"], logLevel: "level"]                                                  | "o"   | configFor(["2019"], "o", null, false, "level")
+        [unityVersions: ["2019"], refreshDependencies: true, logLevel: "level"]                       | "l"   | configFor(["2019"], "l", null, true, "level")
+        [unityVersions: ["2019"], refreshDependencies: false, logLevel: "level"]                      | "l"   | configFor(["2019"], "l", null, false, "level")
+        [unityVersions: ["2019"], sonarToken: "token", refreshDependencies: false, logLevel: "level"] | "l"   | configFor(["2019"], "l", "token", false, "level")
     }
 
     @Unroll
     def "fails to create valid WDKConfig object if config map has null or empty unityVersions list"() {
         given: "a null or empty configuration map"
         when:
-        WDKConfig.fromConfigMap("any", [unityVersions: unityVersions])
+        WDKConfig.fromConfigMap("any", [unityVersions: unityVersions], [:])
         then:
         def e = thrown(IllegalArgumentException)
         e.message == "Please provide at least one unity version."
 
         where:
         unityVersions << [[], null]
+    }
+
+    def configFor(List<String> plats, String label, String sonarToken, boolean refreshDependencies, String logLevel) {
+        new WDKConfig(platsFor(plats, label),
+                SonarQubeArgs.fromConfigMap([sonarToken: sonarToken]),
+                JenkinsMetadata.fromScript(jenkinsScript),
+                refreshDependencies, logLevel, label)
     }
 
 

--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -46,7 +46,7 @@ def call(Map configMap = [:]) {
         }
 
         steps {
-          javaLibCheck config: config, forceSonarQube: params.RUN_SONARQUBE
+          javaLibCheck config: config
         }
         post {
           cleanup {

--- a/vars/buildJavaLibrary.groovy
+++ b/vars/buildJavaLibrary.groovy
@@ -47,7 +47,7 @@ def call(Map configMap = [:]) {
         }
 
         steps {
-          javaLibCheck config: config, forceSonarQube: params.RUN_SONARQUBE
+          javaLibCheck config: config
 
         }
 

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -46,7 +46,7 @@ def call(Map configMap = [:]) {
           }
         }
         steps {
-          javaLibCheck config: config, forceSonarQube: params.RUN_SONARQUBE
+          javaLibCheck config: config
         }
 
         post {

--- a/vars/buildPrivateJavaLibrary.groovy
+++ b/vars/buildPrivateJavaLibrary.groovy
@@ -44,7 +44,7 @@ def call(Map configMap = [:]) {
           expression { return params.RELEASE_TYPE == "snapshot"}
         }
         steps {
-          javaLibCheck config: config, forceSonarQube: params.RUN_SONARQUBE
+          javaLibCheck config: config
         }
 
         post {

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -13,7 +13,7 @@ import net.wooga.jenkins.pipeline.setup.Setups
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 def call(Map configMap = [ unityVersions:[] ]) {
-  def config = WDKConfig.fromConfigMap("macos", configMap)
+  def config = WDKConfig.fromConfigMap("macos", configMap, this)
 
   // We can only configure static pipelines atm.
   // To test multiple unity versions we use a script block with a parallel stages inside.
@@ -111,7 +111,7 @@ def call(Map configMap = [ unityVersions:[] ]) {
             steps {
               script {
                 def gradle = Gradle.fromJenkins(this, params.LOG_LEVEL?: env.LOG_LEVEL as String, params.STACK_TRACE as boolean)
-                def checks = Checks.create(this, gradle, null, BUILD_NUMBER as int)
+                def checks = Checks.create(this, gradle, null, config.metadata.buildNumber as int)
                   def stepsForParallel = checks.wdkCoverage(config,
                           params.RELEASE_TYPE as String, params.RELEASE_SCOPE as String)
                   parallel stepsForParallel

--- a/vars/javaLibCheck.groovy
+++ b/vars/javaLibCheck.groovy
@@ -9,8 +9,7 @@ def call(Map configMap) {
     withEnv(["COVERALLS_PARALLEL=true"]) {
         def gradle = Gradle.fromJenkins(this, params.LOG_LEVEL?: env.LOG_LEVEL as String, params.STACK_TRACE as boolean)
         def checks = Checks.create(this, gradle, config.dockerArgs, config.metadata.buildNumber)
-        def isPR = env.CHANGE_ID as boolean
-        def checksForParallel = checks.javaCoverage(config, isPR)
+        def checksForParallel = checks.javaCoverage(config)
         parallel checksForParallel
     }
 }


### PR DESCRIPTION
## Description
Forgot to add new sonarqube calls for non-plugins projects, so here it is! Also some minor code improvements.


## Changes
* ![ADD] sonarqube calls on non-deprecated java libs and WDK pipelines.


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
