### PR TITLE
Fix test labels config

### DIFF
--- a/src/net/wooga/jenkins/pipeline/config/Platform.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/Platform.groovy
@@ -100,11 +100,16 @@ class Platform {
             return []
         }
         if(obj instanceof Map) {
-            return obj[mapKey] as Collection ?: []
+            def value = obj[mapKey]
+            if(value instanceof String || value instanceof GString) {
+                return [value?.toString()]?: []
+            } else {
+                return obj[mapKey] as Collection ?: []
+            }
         }
         if(obj instanceof Collection) {
             return obj as Collection
         }
-        throw new IllegalArgumentException("${obj} should be a Collection or a Map of [key:collection]")
+        throw new IllegalArgumentException("${obj} should be a Collection or a Map of [key:collection] or [key:string]")
     }
 }

--- a/src/net/wooga/jenkins/pipeline/config/Platform.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/Platform.groovy
@@ -58,7 +58,7 @@ class Platform {
         def generatedLabelsStr = generatedLabels.join(" && ")
 
         return configLabelsStr != null && !configLabelsStr.empty?
-                "${configLabelsStr} && ${generatedLabelsStr}" :
+                "${configLabelsStr} && ${generatedLabelsStr}".toString() :
                 generatedLabelsStr
     }
 

--- a/test/groovy/net/wooga/jenkins/pipeline/config/PlatformSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/PlatformSpec.groovy
@@ -68,6 +68,7 @@ class PlatformSpec extends Specification {
         [testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]                       | buildVersion("v")       | new Platform("v", "macos", false, "", ["t=a", "t2=b"], ["l", "l2"])
         [labels: "label", testLabels: ["t", "t2"]]                                        | buildVersion("v")       | new Platform("v", "macos", false, "label", [], ["t", "t2"])
         [labels: "label", testLabels: [v: ["t", "t2"]]]                                   | buildVersion("v")       | new Platform("v", "macos", false, "label", [], ["t", "t2"])
+        [labels: "label", testLabels: [v: "tag"]]                                         | buildVersion("v")       | new Platform("v", "macos", false, "label", [], ["tag"])
         [labels: "label", testLabels: [notv: ["t", "t2"]]]                                | buildVersion("v")       | new Platform("v", "macos", false, "label", [], [])
         [labels: "label", testEnvironment: [v: ["t=a", "t2=b"]]]                          | buildVersion("v")       | new Platform("v", "macos", false, "label", ["t=a", "t2=b"], [])
         [labels: "label", testEnvironment: [notv: ["t=a", "t2=b"]]]                       | buildVersion("v")       | new Platform("v", "macos", false, "label", [], [])
@@ -96,6 +97,7 @@ class PlatformSpec extends Specification {
         null          | null             | "osname"
         null          | "label && other" | "osname"
         ["testlabel"] | null             | "osname"
+        ["testlabel"] | "label"          | "osname"
         ["testlabel"] | "label"          | "osname"
     }
 


### PR DESCRIPTION
## Description
Fixes bug where a supposed string is actually a GString, and another bug where a testLabels configuration in the format [platform: string] were not supported.

## Changes
* ![FIX] String bug on label generation
* ![FIX] testLabel [platform:string] configuration now is supported



[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
