### PR TITLE
Fixed invalid access to script binding

### DIFF
--- a/vars/buildJavaLibrary.groovy
+++ b/vars/buildJavaLibrary.groovy
@@ -10,11 +10,8 @@ import net.wooga.jenkins.pipeline.TestHelper
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 def call(Map configMap = [:]) {
-  Config config = Config.fromConfigMap(configMap, this.binding.variables)
-
-  def platforms = config.platforms
-  def mainPlatform = platforms[0]
-  def helper = new TestHelper()
+  Config config = Config.fromConfigMap(configMap, this)
+  def mainPlatform = config.platforms[0].name
 
   pipeline {
     agent none

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -10,7 +10,7 @@ import net.wooga.jenkins.pipeline.config.Config
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 def call(Map configMap = [:]) {
-  Config config = Config.fromConfigMap(configMap, this.binding.variables)
+  Config config = Config.fromConfigMap(configMap, this)
   def mainPlatform = config.platforms[0].name
 
   pipeline {


### PR DESCRIPTION
## Description
`buildJavaLibrary` and `buildJavaLibraryOSSRH` were accessing the script `binding` field, which is illegal. Changed that for a valid option.


## Changes
* ![FIX] buildJavaLibraryOSSRH not being able to release due to jenkins sandbox.


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
