### PR TITLE
Adds optional workspace cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation group: 'org.jenkinsci.plugins', name: 'pipeline-model-definition', version: '1.2', ext: 'jar'
     implementation 'org.codehaus.groovy:groovy-all:2.4.12'
 
-    testImplementation "com.lesfurets:jenkins-pipeline-unit:1.3"
+    testImplementation "com.lesfurets:jenkins-pipeline-unit:1.9"
     testImplementation "org.spockframework:spock-core:1.3-groovy-2.4"
     testImplementation  group: "org.jenkins-ci.plugins", name: "script-security", version:"1.78", ext: "jar"
     testImplementation  group: "org.kohsuke", name: "groovy-sandbox", version:"1.27", ext: "jar"

--- a/src/net/wooga/jenkins/pipeline/check/CheckCreator.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/CheckCreator.groovy
@@ -18,7 +18,6 @@ class CheckCreator {
         def catchClosure = {throw it}
         def finallyClosure = {
             jenkins.junit allowEmptyResults: true, testResults: "**/build/test-results/**/*.xml"
-            jenkins.cleanWs()
         }
 
         def checkStep = platform.runsOnDocker ?
@@ -40,7 +39,6 @@ class CheckCreator {
             jenkins.nunit failIfNoResults: false, testResultsPattern: '**/build/reports/unity/test*/*.xml'
             jenkins.archiveArtifacts artifacts: '**/build/logs/**/*.log', allowEmptyArchive: true
             jenkins.archiveArtifacts artifacts: '**/build/reports/unity/**/*.xml', allowEmptyArchive: true
-            jenkins.cleanWs()
         }
         def checkStep = enclosures.simple(versionBuild.platform, mainClosure, catchClosure, finallyClosure)
         return checkStep

--- a/src/net/wooga/jenkins/pipeline/check/Enclosures.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/Enclosures.groovy
@@ -1,5 +1,3 @@
-
-
 package net.wooga.jenkins.pipeline.check
 
 import net.wooga.jenkins.pipeline.check.steps.PackedStep
@@ -18,19 +16,19 @@ class Enclosures {
         this.enclosureCreator = enclosureCreator
     }
 
-    def withDocker(Platform platform, PackedStep mainCls, Closure catchCls = { throw it }, PackedStep finallyCls = {}) {
+    def withDocker(Platform platform, PackedStep mainCls, Closure catchCls = {throw it}, PackedStep finallyCls = {}) {
         enclosureCreator.withNodeAndEnv(platform,
                 withCheckout(platform.checkoutDirectory, { docker.runOnImage(mainCls) }),
                 catchCls,
-                finallyCls
+                withCleanup(platform.clearWs, finallyCls)
         )
     }
 
-    def simple(Platform platform, PackedStep mainClosure, Closure catchCls = { throw it }, PackedStep finallyCls = {}) {
+    def simple(Platform platform, PackedStep mainClosure, Closure catchCls = {throw it}, PackedStep finallyCls = {}) {
         enclosureCreator.withNodeAndEnv(platform,
                 withCheckout(platform.checkoutDirectory, mainClosure),
                 catchCls,
-                finallyCls
+                withCleanup(platform.clearWs, finallyCls)
         )
     }
 
@@ -40,6 +38,15 @@ class Enclosures {
                 jenkins.checkout(jenkins.scm)
             }
             step()
+        }
+    }
+
+    private PackedStep withCleanup(boolean hasCleanup, PackedStep step) {
+        return {
+            step()
+            if(hasCleanup) {
+                jenkins.cleanWs()
+            }
         }
     }
 }

--- a/src/net/wooga/jenkins/pipeline/check/JavaChecks.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/JavaChecks.groovy
@@ -16,10 +16,6 @@ class JavaChecks {
         this.steps = steps
     }
 
-    Closure check(Platform platform, Step testStep, Step analysisStep) {
-        return checkCreator.javaChecks(platform, testStep, analysisStep)
-    }
-
     Map<String, Closure> parallel(Platform[] platforms, Closure checkStep,
                                   PipelineConventions conventions = PipelineConventions.standard) {
         return parallel(platforms, new Step(checkStep), conventions)
@@ -45,6 +41,10 @@ class JavaChecks {
         }
     }
 
+    Closure check(Platform platform, Step testStep, Step analysisStep) {
+        return checkCreator.javaChecks(platform, testStep, analysisStep)
+    }
+
     Map<String, Closure> gradleCheckWithCoverage(Platform[] platforms, CheckArgs checkArgs, PipelineConventions conventions) {
         def baseTestStep = steps.defaultJavaTestStep(conventions.checkTask)
         def baseAnalysisStep = steps.defaultJavaAnalysisStep(conventions, checkArgs.metadata, checkArgs.sonarqube, checkArgs.coveralls)
@@ -53,22 +53,4 @@ class JavaChecks {
                 baseTestStep.wrappedBy(checkArgs.testWrapper),
                 baseAnalysisStep.wrappedBy(checkArgs.analysisWrapper), conventions)
     }
-
-//    static Closure defaultJavaTestStep(String checkTask) {
-//        return { Platform plat, Gradle gradle ->
-//            gradle.wrapper(checkTask)
-//        }
-//    }
-//
-//    static Closure defaultJavaAnalysisStep(PipelineConventions conventions,
-//                                           JenkinsMetadata metadata,
-//                                           Sonarqube sonarqube,
-//                                           Coveralls coveralls) {
-//        return { Platform plat, Gradle gradle ->
-//            def branchName = metadata.isPR() ? null : metadata.branchName
-//            gradle.wrapper(conventions.jacocoTask)
-//            sonarqube.maybeRun(gradle, conventions.sonarqubeTask,  branchName)
-//            coveralls.maybeRun(gradle, conventions.coverallsTask)
-//        }
-//    }
 }

--- a/src/net/wooga/jenkins/pipeline/config/Platform.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/Platform.groovy
@@ -13,6 +13,7 @@ class Platform {
     final Collection<?> testEnv
     final boolean runsOnDocker
     final boolean main
+    final boolean clearWs
 
 
     static Platform forJava(String platformName, Map config, boolean isMain) {
@@ -25,7 +26,8 @@ class Platform {
                 (config.labels ?: '') as String,
                 mapOrCollection(platformName, config.testEnvironment),
                 mapOrCollection(platformName, config.testLabels),
-                isMain
+                isMain,
+                (config.clearWs?: false) as boolean
         )
     }
 
@@ -46,12 +48,13 @@ class Platform {
                 (config.labels ?: '') as String,
                 mapOrCollection(buildVersion.version, config.testEnvironment) + unityEnv,
                 mapOrCollection(buildVersion.version, config.testLabels),
-                isMain
+                isMain,
+                (config.clearWs?: false) as boolean
         )
     }
 
     Platform(String checkoutDirectory, String checkDirectory, String name, String os, boolean runsOnDocker,
-             String labels, Collection<?> testEnvironment, Collection<?> testLabels, boolean main) {
+             String labels, Collection<?> testEnvironment, Collection<?> testLabels, boolean main, boolean clearWs) {
         this.checkoutDirectory = checkoutDirectory
         this.checkDirectory = checkDirectory
         this.name = name
@@ -61,6 +64,7 @@ class Platform {
         this.testLabels = testLabels?.join(" && ")
         this.runsOnDocker = runsOnDocker
         this.main = main
+        this.clearWs = clearWs
     }
 
     String generateTestLabelsString() {

--- a/test/groovy/net/wooga/jenkins/pipeline/config/PlatformSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/PlatformSpec.groovy
@@ -26,20 +26,22 @@ class PlatformSpec extends Specification {
 
         where:
         config                                                                            | isMain | platName | expected
-        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: null]         | true   | "name"   | new Platform(".", ".", "name", "name", false, "", [], [], true)
-        [checkDir: "dir"]                                                                 | false  | "name"   | new Platform(".", "dir", "name", "name", false, "", [], [], false)
-        [checkoutDir: "dir"]                                                              | false  | "name"   | new Platform("dir", ".", "name", "name", false, "", [], [], false)
-        [testEnvironment: ["t=a", "t2=b"]]                                                | false  | "name"   | new Platform(".", ".", "name", "name", false, "", ["t=a", "t2=b"], [], false)
-        [testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]                       | true   | "name"   | new Platform(".", ".", "name", "name", false, "", ["t=a", "t2=b"], ["l", "l2"], true)
-        [labels: "label", testLabels: ["t", "t2"]]                                        | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], ["t", "t2"], false)
-        [labels: "label", testLabels: [name: ["t", "t2"]]]                                | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], ["t", "t2"], false)
-        [labels: "label", testLabels: [notname: ["t", "t2"]]]                             | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], [], false)
-        [labels: "label", testEnvironment: [name: ["t=a", "t2=b"]]]                       | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", ["t=a", "t2=b"], [], false)
-        [labels: "label", testEnvironment: [notname: ["t=a", "t2=b"]]]                    | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], [], false)
-        [labels: "label", testEnvironment: ["t=a", "t2=b"]]                               | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", ["t=a", "t2=b"], [], false)
-        [labels: "label", testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]      | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", ["t=a", "t2=b"], ["l", "l2"], false)
-        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | "name"   | new Platform(".", ".", "name", "name", false, "", [], [], false)
-        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | "linux"  | new Platform(".", ".", "linux", "linux", true, "", [], [], false)
+        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: null]         | true   | "name"   | new Platform(".", ".", "name", "name", false, "", [], [], true, false)
+        [checkDir: "dir"]                                                                 | false  | "name"   | new Platform(".", "dir", "name", "name", false, "", [], [], false, false)
+        [checkoutDir: "dir"]                                                              | false  | "name"   | new Platform("dir", ".", "name", "name", false, "", [], [], false, false)
+        [checkoutDir: "dir", clearWs: true]                                               | false  | "name"   | new Platform("dir", ".", "name", "name", false, "", [], [], false, true)
+        [clearWs: true]                                                                   | false  | "name"   | new Platform("dir", ".", "name", "name", false, "", [], [], false, true)
+        [testEnvironment: ["t=a", "t2=b"]]                                                | false  | "name"   | new Platform(".", ".", "name", "name", false, "", ["t=a", "t2=b"], [], false, false)
+        [testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]                       | true   | "name"   | new Platform(".", ".", "name", "name", false, "", ["t=a", "t2=b"], ["l", "l2"], true, false)
+        [labels: "label", testLabels: ["t", "t2"]]                                        | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], ["t", "t2"], false, false)
+        [labels: "label", testLabels: [name: ["t", "t2"]]]                                | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], ["t", "t2"], false, false)
+        [labels: "label", testLabels: [notname: ["t", "t2"]]]                             | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], [], false, false)
+        [labels: "label", testEnvironment: [name: ["t=a", "t2=b"]]]                       | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", ["t=a", "t2=b"], [], false, false)
+        [labels: "label", testEnvironment: [notname: ["t=a", "t2=b"]]]                    | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", [], [], false, false)
+        [labels: "label", testEnvironment: ["t=a", "t2=b"]]                               | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", ["t=a", "t2=b"], [], false, false)
+        [labels: "label", testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]      | false  | "name"   | new Platform(".", ".", "name", "name", false, "label", ["t=a", "t2=b"], ["l", "l2"], false, false)
+        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | "name"   | new Platform(".", ".", "name", "name", false, "", [], [], false, false)
+        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | "linux"  | new Platform(".", ".", "linux", "linux", true, "", [], [], false, false)
     }
 
 
@@ -69,28 +71,30 @@ class PlatformSpec extends Specification {
 
         where:
         config                                                                            | isMain | buildVersion            | expected
-        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: null]         | true   | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", [], [], true)
-        [checkDir: "dir"]                                                                 | false  | buildVersion("v")       | new Platform("v", "dir", "v", "macos", false, "", [], [], false)
-        [checkoutDir: "dir"]                                                              | false  | buildVersion("v")       | new Platform("dir", ".", "v", "macos", false, "", [], [], false)
-        [testEnvironment: ["t=a", "t2=b"]]                                                | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", ["t=a", "t2=b"], [], false)
-        [testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]                       | true   | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", ["t=a", "t2=b"], ["l", "l2"], true)
-        [labels: "label", testLabels: ["t", "t2"]]                                        | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], ["t", "t2"], false)
-        [labels: "label", testLabels: [v: ["t", "t2"]]]                                   | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], ["t", "t2"], false)
-        [labels: "label", testLabels: [v: "tag"]]                                         | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], ["tag"], false)
-        [labels: "label", testLabels: [notv: ["t", "t2"]]]                                | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], [], false)
-        [labels: "label", testEnvironment: [v: ["t=a", "t2=b"]]]                          | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", ["t=a", "t2=b"], [], false)
-        [labels: "label", testEnvironment: [notv: ["t=a", "t2=b"]]]                       | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], [], false)
-        [labels: "label", testEnvironment: ["t=a", "t2=b"]]                               | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", ["t=a", "t2=b"], [], false)
-        [labels: "label", testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]      | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", ["t=a", "t2=b"], ["l", "l2"], false)
-        [labels: "label", testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]      | false  | buildVersion("v", "lv") | new Platform("v_lv", ".", "v", "macos", false, "label", ["t=a", "t2=b"], ["l", "l2"], false)
-        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", [], [], false)
-        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | buildVersion("v", "lv") | new Platform("v_lv", ".", "v", "macos", false, "", [], [], false)
+        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: null]         | true   | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", [], [], true, false)
+        [checkDir: "dir"]                                                                 | false  | buildVersion("v")       | new Platform("v", "dir", "v", "macos", false, "", [], [], false, false)
+        [checkoutDir: "dir"]                                                              | false  | buildVersion("v")       | new Platform("dir", ".", "v", "macos", false, "", [], [], false, false)
+        [checkoutDir: "dir", clearWs: true]                                               | false  | buildVersion("v")       | new Platform("dir", ".", "v", "macos", false, "", [], [], false, true)
+        [clearWs: true]                                                                   | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", [], [], false, true)
+        [testEnvironment: ["t=a", "t2=b"]]                                                | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", ["t=a", "t2=b"], [], false, false)
+        [testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]                       | true   | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", ["t=a", "t2=b"], ["l", "l2"], true, false)
+        [labels: "label", testLabels: ["t", "t2"]]                                        | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], ["t", "t2"], false, false)
+        [labels: "label", testLabels: [v: ["t", "t2"]]]                                   | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], ["t", "t2"], false, false)
+        [labels: "label", testLabels: [v: "tag"]]                                         | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], ["tag"], false, false)
+        [labels: "label", testLabels: [notv: ["t", "t2"]]]                                | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], [], false, false)
+        [labels: "label", testEnvironment: [v: ["t=a", "t2=b"]]]                          | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", ["t=a", "t2=b"], [], false, false)
+        [labels: "label", testEnvironment: [notv: ["t=a", "t2=b"]]]                       | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", [], [], false, false)
+        [labels: "label", testEnvironment: ["t=a", "t2=b"]]                               | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", ["t=a", "t2=b"], [], false, false)
+        [labels: "label", testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]      | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "label", ["t=a", "t2=b"], ["l", "l2"], false, false)
+        [labels: "label", testEnvironment: ["t=a", "t2=b"], testLabels: ["l", "l2"]]      | false  | buildVersion("v", "lv") | new Platform("v_lv", ".", "v", "macos", false, "label", ["t=a", "t2=b"], ["l", "l2"], false, false)
+        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | buildVersion("v")       | new Platform("v", ".", "v", "macos", false, "", [], [], false, false)
+        [labels: null, testEnvironment: null, testLabels: null, dockerArgs: [not: "nul"]] | false  | buildVersion("v", "lv") | new Platform("v_lv", ".", "v", "macos", false, "", [], [], false, false)
     }
 
     @Unroll
     def "generates test label string"() {
         given: "a valid platform"
-        def platform = new Platform(".", ".", "platname", os, false, labels, [], testLabels, false)
+        def platform = new Platform(".", ".", "platname", os, false, labels, [], testLabels, false, false)
         when: "generating test label string"
         def labelsStr = platform.generateTestLabelsString()
         then:
@@ -120,7 +124,7 @@ class PlatformSpec extends Specification {
         def platform = Platform.forWDK(autoBuildVer, "macos", config, true)
 
         then: "created platform doesn't have the UVM_UNITY_VERSION environment"
-        platform.testEnvironment.find{it.trim().startsWith("UVM_UNITY_VERSION=")} == null
+        platform.testEnvironment.find { it.trim().startsWith("UVM_UNITY_VERSION=") } == null
         platform.testEnvironment == config.testEnvironment + ["UNITY_LOG_CATEGORY=check-project_version"]
     }
 

--- a/test/groovy/scripts/BuildGradlePluginSpec.groovy
+++ b/test/groovy/scripts/BuildGradlePluginSpec.groovy
@@ -88,27 +88,27 @@ class BuildGradlePluginSpec extends DeclarativeJenkinsSpec {
         env["GITHUB_PASSWORD"] == "pwd" //"${GRGIT_PSW}"
     }
 
-    @Unroll("checks out step in #checkoutDir")
-    def "checks out step on given checkoutDir"() {
+
+
+    @Unroll("#description publish workspace when clearWs is #clearWs")
+    def "clears publish and preparation workspaces if clearWs is set"() {
         given: "loaded check in a running jenkins build"
-        def buildGradlePlugin = loadSandboxedScript(SCRIPT_PATH) {}
-
-        and: "wired checkout operation"
-        def actualCheckoutDir = ""
-        helper.registerAllowedMethod("checkout", [String]) {
-            actualCheckoutDir = it
+        def buildGradlePlugin = loadSandboxedScript(SCRIPT_PATH) {
+            params.RELEASE_TYPE = "not-snapshot"
+            params.RELEASE_SCOPE = "any"
         }
 
-        when: "running check"
+        when: "running pipeline"
         inSandbox {
-            buildGradlePlugin(platforms: ["linux"], checkoutDir: checkoutDir)
+            buildGradlePlugin(platforms: ["linux"], clearWs: clearWs)
         }
 
-        then: "checkout ran in given directory"
-        checkoutDir == actualCheckoutDir
+        then: "all workspaces are clean"
+        calls["cleanWs"].length == (clearWs? 2 : 0) //publish (1) + preparation (1)
 
         where:
-        checkoutDir << [".", "dir", "dir/subdir"]
+        clearWs << [true, false]
+        description = clearWs? "clears" : "doesn't clear"
     }
 
     String[] getShGradleCalls() {

--- a/test/groovy/scripts/BuildGradlePluginSpec.groovy
+++ b/test/groovy/scripts/BuildGradlePluginSpec.groovy
@@ -88,6 +88,29 @@ class BuildGradlePluginSpec extends DeclarativeJenkinsSpec {
         env["GITHUB_PASSWORD"] == "pwd" //"${GRGIT_PSW}"
     }
 
+    @Unroll("checks out step in #checkoutDir")
+    def "checks out step on given checkoutDir"() {
+        given: "loaded check in a running jenkins build"
+        def buildGradlePlugin = loadSandboxedScript(SCRIPT_PATH) {}
+
+        and: "wired checkout operation"
+        def actualCheckoutDir = ""
+        helper.registerAllowedMethod("checkout", [String]) {
+            actualCheckoutDir = it
+        }
+
+        when: "running check"
+        inSandbox {
+            buildGradlePlugin(platforms: ["linux"], checkoutDir: checkoutDir)
+        }
+
+        then: "checkout ran in given directory"
+        checkoutDir == actualCheckoutDir
+
+        where:
+        checkoutDir << [".", "dir", "dir/subdir"]
+    }
+
     String[] getShGradleCalls() {
         return calls["sh"].collect { it.args[0]["script"].toString() }.findAll {
             it.contains("gradlew")

--- a/test/groovy/scripts/JavaCheckSpec.groovy
+++ b/test/groovy/scripts/JavaCheckSpec.groovy
@@ -322,31 +322,6 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         } == 1
     }
 
-    @Unroll("checks out step in #checkoutDir")
-    def "checks out step on given checkoutDir"() {
-        given: "loaded check in a running jenkins build"
-        def check = loadSandboxedScript(TEST_SCRIPT_PATH)
-        and: "configuration object with any platforms"
-        def configMap = [platforms: ["linux"], checkoutDir: checkoutDir]
-        and: "wired checkout operation"
-        def actualCheckoutDir = ""
-        helper.registerAllowedMethod("checkout", [String]) {
-            actualCheckoutDir = this.currentDir
-        }
-
-        when: "running check"
-        inSandbox {
-            Map<String, Closure> checkSteps = check.javaCoverage(configMap)
-            checkSteps.each { it.value.call() }
-        }
-
-        then: "checkout ran in given directory"
-        checkoutDir == actualCheckoutDir
-
-        where:
-        checkoutDir << [".", "dir", "dir/subdir"]
-    }
-
     @Unroll("runs test and analysis step on #checkDir")
     def "runs test and analysis step on given checkDir"() {
         given: "loaded check in a running jenkins build"

--- a/test/groovy/scripts/WDKCheckSpec.groovy
+++ b/test/groovy/scripts/WDKCheckSpec.groovy
@@ -409,33 +409,6 @@ class WDKCheckSpec extends DeclarativeJenkinsSpec {
         analysisCount.get() == 1
     }
 
-    @Unroll("checks out code on step in #checkoutDir")
-    def "checks out code on step in given checkoutDir"() {
-        given: "loaded check in a running jenkins build"
-        def check = loadSandboxedScript(TEST_SCRIPT_PATH)
-        and: "configuration object with any platforms"
-        def configMap = [unityVersions: ["2019"], checkoutDir: checkoutDir]
-        and: "stashed setup"
-        jenkinsStash[PipelineConventions.standard.wdkSetupStashId] = [:]
-
-        when: "running check"
-        def actualCheckoutDir = ""
-        helper.registerAllowedMethod("checkout", [String]) {
-            actualCheckoutDir = this.currentDir
-        }
-        inSandbox {
-            Map<String, Closure> checkSteps = check.wdkCoverage("label", configMap, "any", "any")
-            checkSteps.each { it.value.call() }
-        }
-
-        then: "steps ran on given directory"
-        //checks steps + 1 analysis step
-        checkoutDir == actualCheckoutDir
-
-        where:
-        checkoutDir << [".", "dir", "dir/subdir"]
-    }
-
     @Unroll("runs test and analysis step on #checkDir")
     def "runs test and analysis step on given checkDir"() {
         given: "loaded check in a running jenkins build"

--- a/test/groovy/tools/DeclarativeJenkinsSpec.groovy
+++ b/test/groovy/tools/DeclarativeJenkinsSpec.groovy
@@ -96,7 +96,6 @@ abstract class DeclarativeJenkinsSpec extends Specification {
                             collectEntries{String envStr -> [(envStr.split("=")[0]): envStr.split("=")[1]]}
                 environment.runWithEnv(env, cls)
             }
-            registerAllowedMethod("cleanWs") {}
             registerAllowedMethod("checkout", [String]) {}
             registerAllowedMethod("publishHTML", [HashMap]) {}
             registerAllowedMethod("fileExists", [String]) { String path -> new File(path).exists() }
@@ -134,8 +133,9 @@ abstract class DeclarativeJenkinsSpec extends Specification {
     private static void addLackingDSLTerms() {
         GenericPipelineDeclaration.metaClass.any = "any"
         WhenDeclaration.metaClass.beforeAgent = { bool -> null }
-        PostDeclaration.metaClass.cleanup = { clj -> clj() }
-        PostDeclaration.metaClass.cleanWs = {}
+//        PostDeclaration.metaClass.cleanup = { cls -> cls() }
+//        PostDeclaration.metaClass.script = { cls -> cls() }
+//        PostDeclaration.metaClass.cleanWs = {}
     }
 
     /**

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -16,7 +16,9 @@ def call(Map configMap = [ unityVersions:[] ]) {
   configMap.logLevel = configMap.get("logLevel", params.LOG_LEVEL?: env.LOG_LEVEL as String)
   configMap.showStackTrace = configMap.get("showStackTrace", params.STACK_TRACE as Boolean)
   configMap.refreshDependencies = configMap.get("refreshDependencies", params.REFRESH_DEPENDENCIES as Boolean)
+  configMap.clearWs = configMap.get("clearWs", params.CLEAR_WS as boolean)
   def config = WDKConfig.fromConfigMap("macos", configMap, this)
+  def mainPlatform = config.unityVersions[0].platform
 
   // We can only configure static pipelines atm.
   // To test multiple unity versions we use a script block with a parallel stages inside.
@@ -41,6 +43,8 @@ def call(Map configMap = [ unityVersions:[] ]) {
       choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
       booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
       booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
+      booleanParam(defaultValue: false, description: 'Whether to clear workspaces after build', name: 'CLEAR_WS')
+
     }
 
     stages {
@@ -68,7 +72,11 @@ def call(Map configMap = [ unityVersions:[] ]) {
           }
 
           cleanup {
-            cleanWs()
+            script {
+              if(mainPlatform.clearWs) {
+                cleanWs()
+              }
+            }
           }
         }
       }
@@ -97,7 +105,11 @@ def call(Map configMap = [ unityVersions:[] ]) {
                 archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
               }
               cleanup {
-                cleanWs()
+                script {
+                  if(mainPlatform.clearWs) {
+                    cleanWs()
+                  }
+                }
               }
             }
           }
@@ -154,7 +166,11 @@ def call(Map configMap = [ unityVersions:[] ]) {
             archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
           }
           cleanup {
-            cleanWs()
+            script {
+              if(mainPlatform.clearWs) {
+                cleanWs()
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

Removed mandatory cleanup for pipelines, now it is optional, enabled through a parameter. Based on PR #105.


## Changes
* ![CHANGE] workspace cleanup now disabled by default 
* ![ADD] workspace cleanup pipeline parameters



[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
