### PR TITLE
Add private gradle plugin pipeline

### DIFF
--- a/vars/buildPrivateGradlePlugin.groovy
+++ b/vars/buildPrivateGradlePlugin.groovy
@@ -1,0 +1,24 @@
+#!/usr/bin/env groovy
+import net.wooga.jenkins.pipeline.config.JavaConfig
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                                                    //
+// Step buildJavaLibrary                                                                                              //
+//                                                                                                                    //
+//                                                                                                                    //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+def call(Map configMap = [:]) {
+    javaLibs(configMap) { stages ->
+        stages.publish = { stage, params, JavaConfig config ->
+            stage.when = { true } //always
+            stage.action = {
+                def publisher = config.pipelineTools.createPublishers(params.RELEASE_TYPE, params.RELEASE_SCOPE)
+                publisher.artifactoryOSSRH('artifactory_publish',
+                            'ossrh.signing.key',
+                            'ossrh.signing.key_id',
+                        'ossrh.signing.passphrase')
+            }
+        }
+    }
+}

--- a/vars/buildPrivateGradlePlugin.txt
+++ b/vars/buildPrivateGradlePlugin.txt
@@ -1,0 +1,14 @@
+Custom step to build,test and deploy private atlas gradle plugins.
+
+usage:
+
+```
+def coveralls_token = "coveralls token" //can be null
+
+def testEnvironment = [
+                        "test_var_1=value1",
+                        "test_var_2=value2"
+                       ]
+
+buildPrivateGradlePlugin plaforms: ['macos'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
+```


### PR DESCRIPTION
## Description
Adds private gradle plugin pipeline, which is just the private java lib, but with its own name/file. 

## Changes
* ![ADD] Private gradle plugin pipeline.



[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
