### PR TITLE
Fixed dockerargs object argument strings and improved tests

### DIFF
--- a/src/net/wooga/jenkins/pipeline/check/CheckCreator.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/CheckCreator.groovy
@@ -49,7 +49,6 @@ class CheckCreator {
     protected Step createCheck(Step testStep, Step analysisStep) {
         return new Step({ Platform platform ->
             jenkins.dir(platform.checkoutDirectory) {
-                jenkins.checkout(jenkins.scm)
                 jenkins.dir(platform.checkDirectory) {
                     testStep(platform)
                     if (platform.isMain()) {

--- a/src/net/wooga/jenkins/pipeline/check/Checks.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/Checks.groovy
@@ -18,7 +18,7 @@ class Checks {
     //for non-trivial constructors, prefer static factories.
     static Checks create(Object jenkinsScript, Docker docker, Gradle gradle, int buildNumber) {
         def enclosureCreator = new EnclosureCreator(jenkinsScript, buildNumber)
-        def enclosures = new Enclosures(docker, enclosureCreator)
+        def enclosures = new Enclosures(jenkinsScript, docker, enclosureCreator)
         def checkCreator = new CheckCreator(jenkinsScript, enclosures)
         def steps = new GradleSteps(jenkinsScript, gradle)
 

--- a/src/net/wooga/jenkins/pipeline/check/Enclosures.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/Enclosures.groovy
@@ -1,27 +1,45 @@
+
+
 package net.wooga.jenkins.pipeline.check
 
 import net.wooga.jenkins.pipeline.check.steps.PackedStep
-import net.wooga.jenkins.pipeline.config.DockerArgs
 import net.wooga.jenkins.pipeline.config.Platform
 import net.wooga.jenkins.pipeline.model.Docker
 
 class Enclosures {
 
+    private Object jenkins
     private Docker docker
     private EnclosureCreator enclosureCreator
 
-    Enclosures(Docker docker, EnclosureCreator enclosureCreator) {
+    Enclosures(Object jenkins, Docker docker, EnclosureCreator enclosureCreator) {
+        this.jenkins = jenkins
         this.docker = docker
         this.enclosureCreator = enclosureCreator
     }
 
-    def withDocker(Platform platform, PackedStep mainCls, Closure catchCls = {throw it}, PackedStep finallyCls = {}) {
-        enclosureCreator.withNodeAndEnv(platform, {
-            docker.runOnImage(mainCls)
-        }, catchCls, finallyCls)
+    def withDocker(Platform platform, PackedStep mainCls, Closure catchCls = { throw it }, PackedStep finallyCls = {}) {
+        enclosureCreator.withNodeAndEnv(platform,
+                withCheckout(platform.checkoutDirectory, { docker.runOnImage(mainCls) }),
+                catchCls,
+                finallyCls
+        )
     }
 
-    def simple(Platform platform, PackedStep mainClosure, Closure catchCls = {throw it}, PackedStep finallyCls = {}) {
-        enclosureCreator.withNodeAndEnv(platform, mainClosure, catchCls, finallyCls)
+    def simple(Platform platform, PackedStep mainClosure, Closure catchCls = { throw it }, PackedStep finallyCls = {}) {
+        enclosureCreator.withNodeAndEnv(platform,
+                withCheckout(platform.checkoutDirectory, mainClosure),
+                catchCls,
+                finallyCls
+        )
+    }
+
+    private PackedStep withCheckout(String checkoutDir, PackedStep step) {
+        return {
+            jenkins.dir(checkoutDir) {
+                jenkins.checkout(jenkins.scm)
+            }
+            step()
+        }
     }
 }

--- a/src/net/wooga/jenkins/pipeline/config/DockerArgs.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/DockerArgs.groovy
@@ -32,7 +32,12 @@ class DockerArgs {
     }
 
     String getDockerBuildString() {
-        return "-f ${fileName} ${buildArgs} ${fileDirectory}".toString()
+        def args = ["-f ${fileName}".toString()]
+        if(buildArgs.size() > 0) {
+            args.add(buildArgs.join(" "))
+        }
+        args.add(fileDirectory)
+        return args.join(" ").toString()
     }
 
     String getDockerImageArgs() {
@@ -60,6 +65,18 @@ class DockerArgs {
         result = 31 * result + (fileName != null ? fileName.hashCode() : 0)
         result = 31 * result + (fileDirectory != null ? fileDirectory.hashCode() : 0)
         return result
+    }
+
+
+    @Override
+    String toString() {
+        return "DockerArgs{" +
+                "image='" + image + '\'' +
+                ", fileName='" + fileName + '\'' +
+                ", fileDirectory='" + fileDirectory + '\'' +
+                ", buildArgs=" + Arrays.toString(buildArgs) +
+                ", imageArgs=" + Arrays.toString(imageArgs) +
+                '}';
     }
 }
 

--- a/src/net/wooga/jenkins/pipeline/model/Docker.groovy
+++ b/src/net/wooga/jenkins/pipeline/model/Docker.groovy
@@ -19,7 +19,10 @@ class Docker {
     void runOnImage(PackedStep main) {
         def image = createImage(dockerArgs)
         if(image != null) {
-            image.inside(dockerArgs.dockerImageArgs) { main.call() }
+            image.inside(dockerArgs.dockerImageArgs) {
+                jenkins.echo("Running inside Dockerfile")
+                main.call()
+            }
         } else {
             main.call()
         }

--- a/src/net/wooga/jenkins/pipeline/model/Docker.groovy
+++ b/src/net/wooga/jenkins/pipeline/model/Docker.groovy
@@ -29,8 +29,10 @@ class Docker {
     }
 
     protected Object createImage(DockerArgs args) {
+
         def docker = jenkins.docker
         if (args.image) {
+            jenkins.echo("Using given image $args.image")
             return docker.image(args.image)
         } else {
             if (jenkins.fileExists(args.fullFilePath)) {
@@ -38,6 +40,7 @@ class Docker {
                 def hash = jenkins.utils().stringToSHA1(dockerfileContent + "/n" + args.dockerBuildString)
                 return docker.build(hash, args.dockerBuildString)
             }
+            jenkins.echo("Dockerfile $args.fullFilePath not found")
         }
         return null;
     }

--- a/test/groovy/net/wooga/jenkins/pipeline/config/DockerArgsSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/DockerArgsSpec.groovy
@@ -26,4 +26,56 @@ class DockerArgsSpec extends Specification {
         null    | null     | null    | null      | ["arg"]  | new DockerArgs(null, "Dockerfile", ".", [], ["arg"])
         "image" | "file"   | "dir"   | ["barg"]  | ["darg"] | new DockerArgs("image", "file", "dir", ["barg"], ["darg"])
     }
+
+    @Unroll
+    def "generates docker build arguments string"() {
+        given:
+        when:
+        def buildString = dockerArgs.dockerBuildString
+        then:
+        expectedBuildString == buildString
+
+        where:
+        dockerArgs                                                                     | expectedBuildString
+        new DockerArgs(null, "Dockerfile", ".", [], [])                                | "-f Dockerfile ."
+        new DockerArgs(null, "file", ".", [], [])                                      | "-f file ."
+        new DockerArgs(null, "Dockerfile", "dir", [], [])                              | "-f Dockerfile dir"
+        new DockerArgs(null, "Dockerfile", ".", ["-arg value"], [])                    | "-f Dockerfile -arg value ."
+        new DockerArgs(null, "Dockerfile", ".", ["-arg value", "-arg othervalue"], []) | "-f Dockerfile -arg value -arg othervalue ."
+        new DockerArgs(null, "Dockerfile", ".", [], ['arg'])                           | "-f Dockerfile ."
+    }
+
+    @Unroll
+    def "generates docker image arguments string"() {
+        given:
+        when:
+        def buildString = dockerArgs.dockerImageArgs
+        then:
+        expectedImageString == buildString
+
+        where:
+        dockerArgs                                                             | expectedImageString
+        new DockerArgs(null, "Dockerfile", ".", [], [])                        | ""
+        new DockerArgs("image", "file", ".", [], [])                           | ""
+        new DockerArgs("image", "file", ".", [], ["-arg value"])               | "-arg value"
+        new DockerArgs("image", "file", ".", [], ["-arg value", "othervalue"]) | "-arg value othervalue"
+        new DockerArgs(null, "file", ".", [], ["-arg value", "othervalue"])    | "-arg value othervalue"
+    }
+
+
+    @Unroll
+    def "generates dockerfile full path"() {
+        given:
+        when:
+        def buildString = dockerArgs.fullFilePath
+        then:
+        expectedPath == buildString
+
+        where:
+        dockerArgs                                                 | expectedPath
+        new DockerArgs(null, "Dockerfile", ".", [], [])            | "./Dockerfile"
+        new DockerArgs("image", "file", ".", [], [])               | "./file"
+        new DockerArgs("image", "file", "dir", [], ["-arg value"]) | "dir/file"
+    }
 }
+

--- a/test/groovy/scripts/BuildGradlePluginSpec.groovy
+++ b/test/groovy/scripts/BuildGradlePluginSpec.groovy
@@ -7,14 +7,12 @@ import tools.DeclarativeJenkinsSpec
 class BuildGradlePluginSpec extends DeclarativeJenkinsSpec {
     private static final String SCRIPT_PATH = "vars/buildGradlePlugin.groovy"
 
-    def setupSpec() {
+    def setup() {
         binding.setVariable("params", [RELEASE_TYPE: "snapshot"])
-        binding.setVariable("BRANCH_NAME", "any")
     }
 
     def "posts coveralls results to coveralls server"() {
         given: "loaded buildGradlePlugin in a successful build"
-        helper.registerAllowedMethod("httpRequest", [LinkedHashMap]) {}
         def buildGradlePlugin = loadSandboxedScript(SCRIPT_PATH) {
             currentBuild["result"] = "SUCCESS"
         }

--- a/test/groovy/scripts/BuildWDKAutoSwitchSpec.groovy
+++ b/test/groovy/scripts/BuildWDKAutoSwitchSpec.groovy
@@ -7,9 +7,6 @@ import tools.DeclarativeJenkinsSpec
 class BuildWDKAutoSwitchSpec extends DeclarativeJenkinsSpec {
     private static final String SCRIPT_PATH = "vars/buildWDKAutoSwitch.groovy"
 
-    def setupSpec() {
-    }
-
     @Unroll("publishes #releaseType-#releaseScope release ")
     def "publishes WDK with #release release type"() {
         given: "credentials holder with publish keys"

--- a/test/groovy/scripts/JavaCheckSpec.groovy
+++ b/test/groovy/scripts/JavaCheckSpec.groovy
@@ -123,7 +123,7 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         and: "a fake dockerfile"
         createTmpFile(dockerDir, dockerfile)
         and: "a mocked jenkins docker object"
-        def dockerMock = createDockerMock(dockerfile, image, dockerDir, dockerBuildArgs, dockerArgs)
+        def dockerMock = createDockerFake(dockerfile, image, dockerDir, dockerBuildArgs, dockerArgs)
         def check = loadSandboxedScript(TEST_SCRIPT_PATH) {
             docker = dockerMock
         }
@@ -388,7 +388,8 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         }
     }
 
-    def createDockerMock(String dockerfile, String image, String dockerDir,
+    //TODO: create a proper mock for this
+    def createDockerFake(String dockerfile, String image, String dockerDir,
                          List<String> dockerBuildArgs, List<String> dockerArgs) {
         AtomicBoolean ran = new AtomicBoolean(false)
         def imgMock = [inside: { args, cls ->
@@ -397,9 +398,14 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
                 cls()
             }
         }]
-        def buildArgs = "-f ${dockerfile} ${dockerBuildArgs} ${dockerDir}"
+
+        def buildArgs = ["-f ${dockerfile}".toString()]
+        if(dockerBuildArgs?.size() > 0) {
+            buildArgs.add(dockerBuildArgs.join(" "))
+        }
+        buildArgs.add(dockerDir)
         return [image: { name -> name == image ? imgMock : null },
-                build: { hash, args -> args == buildArgs ? imgMock : null },
+                build: { hash, args -> args == buildArgs.join(" ") ? imgMock : null },
                 ran  : ran]
     }
 }

--- a/test/groovy/tools/DeclarativeJenkinsSpec.groovy
+++ b/test/groovy/tools/DeclarativeJenkinsSpec.groovy
@@ -80,6 +80,7 @@ abstract class DeclarativeJenkinsSpec extends Specification {
 
     private void registerPipelineFakeMethods(PipelineTestHelper helper) {
         helper.with {
+            registerAllowedMethod("httpRequest", [LinkedHashMap]) {}
             registerAllowedMethod("isUnix") { true }
             registerAllowedMethod("sendSlackNotification", [String, boolean]) {}
             registerAllowedMethod("junit", [LinkedHashMap]) {}


### PR DESCRIPTION
## Description
Arguments generation for Docker projects with docker containers are broken, as build arguments would enter the real argument list as an array, instead of a string with space separated arguments. Tests were testing the wrong string as well, so they couldn't catch the error. Added another layer of unit tests for the DockerArgs object and the jenkins-level tests now tests the right behavior.

Branch based on `fix/late-checkout` (#105)

## Changes
* ![FIX] argument generation bug for Docker projects




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
