### PR TITLE
Fixes agent label on publish stage

### DIFF
--- a/test/groovy/scripts/BuildWDKJSSpec.groovy
+++ b/test/groovy/scripts/BuildWDKJSSpec.groovy
@@ -353,4 +353,23 @@ class BuildWDKJSSpec extends DeclarativeJenkinsSpec {
         env["GITHUB_PASSWORD"] == "gitpwd" //"${GRGIT_PSW}"
     }
 
+    @Unroll
+    def "publish step is executed on #mainPlatform label"() {
+        given: "pipeline loaded with publish parameters"
+        def buildWDKJS = loadSandboxedScript(SCRIPT_PATH) {
+            params.RELEASE_TYPE = "not-snapshot"
+            params.RELEASE_SCOPE = "any"
+        }
+
+        when: "running pipeline"
+        inSandbox { buildWDKJS(platforms: platforms) }
+
+        then: "publish step is executed with expected label"
+        pipeline.stages["publish"].agent.label == "$mainPlatform && atlas"
+
+        where:
+        platforms << [["macos", "windows"], ["linux"]]
+        mainPlatform = platforms?.get(0)
+    }
+
 }

--- a/test/groovy/tools/DeclarativeJenkinsSpec.groovy
+++ b/test/groovy/tools/DeclarativeJenkinsSpec.groovy
@@ -2,6 +2,7 @@ package tools
 
 
 import com.lesfurets.jenkins.unit.PipelineTestHelper
+import com.lesfurets.jenkins.unit.declarative.DeclarativePipeline
 import com.lesfurets.jenkins.unit.declarative.DeclarativePipelineTest
 import com.lesfurets.jenkins.unit.declarative.GenericPipelineDeclaration
 import com.lesfurets.jenkins.unit.declarative.PostDeclaration
@@ -33,6 +34,7 @@ abstract class DeclarativeJenkinsSpec extends Specification {
     @Shared FakeEnvironment environment
     @Shared Map<String, Map> jenkinsStash
     @Shared String currentDir
+    @Shared GenericPipelineDeclaration pipeline
 
     def setupSpec() {
         jenkinsStash = new HashMap<>()
@@ -41,6 +43,11 @@ abstract class DeclarativeJenkinsSpec extends Specification {
                 new PackageWhitelist("com.lesfurets.jenkins"),
                 new PackageWhitelist("net.wooga.jenkins.pipeline")
         ))
+        jenkinsTest.pipelineInterceptor = { Closure cls ->
+            GenericPipelineDeclaration.binding = binding
+            this.pipeline = GenericPipelineDeclaration.createComponent(DeclarativePipeline, cls)
+            this.pipeline.execute(delegate)
+        }
         jenkinsTest.setUp()
         credentials = new FakeCredentialStorage()
         environment = new FakeEnvironment(jenkinsTest.binding)

--- a/vars/buildWDKJS.groovy
+++ b/vars/buildWDKJS.groovy
@@ -16,7 +16,7 @@ def call(Map configMap = [:]) {
     configMap.clearWs = configMap.get("clearWs", params.CLEAR_WS as boolean)
     def config  = JSConfig.fromConfigMap(configMap, this)
     def platforms = config.platforms
-    def mainPlatform = platforms[0]
+    def mainPlatform = platforms[0].name
 
     pipeline {
         agent none


### PR DESCRIPTION
## Description
Solved bug on JS pipeline where a complex object was on the publish stage label instead of a string.

## Changes
* ![ADD] add new file x.cs
* ![FIX] WDK JS pipeline publish stage label

[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
