### PR TITLE
[ATLAS-831] Adds buildLocalGradlePlugin pipeline using inner plugin as sample

### DIFF
--- a/atlas-jenkins-pipeline-gradle/Jenkinsfile
+++ b/atlas-jenkins-pipeline-gradle/Jenkinsfile
@@ -1,129 +1,22 @@
 #!groovy
-@Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
+@Library('github.com/wooga/atlas-jenkins-pipeline@detach/test-lib') _
 
-import net.wooga.jenkins.pipeline.TestHelper
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//                                                                                                                    //
-// Step buildLocalGradlePlugin                                                                                        //
-//                                                                                                                    //
-//                                                                                                                    //
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-def call(Map config = [:]) {
-  //set config defaults
-  config.platforms = config.platforms ?: config.plaforms ?: ['macos','windows']
-  config.testEnvironment = config.testEnvironment ?: []
-  config.testLabels = config.testLabels ?: []
-  config.labels = config.labels ?: ''
-  config.sonarQubeBranchPattern = config.sonarQubeBranchPattern ?: "^(master|main)\$"
-  config.dockerArgs = config.dockerArgs ?: [:]
-  config.dockerArgs.dockerFileName = config.dockerArgs.dockerFileName ?: "Dockerfile"
-  config.dockerArgs.dockerFileDirectory = config.dockerArgs.dockerFileDirectory ?: "."
-  config.dockerArgs.dockerBuildArgs = config.dockerArgs.dockerBuildArgs ?: []
-  config.dockerArgs.dockerArgs = config.dockerArgs.dockerArgs ?: []
-
-  def platforms = config.platforms
-  def mainPlatform = platforms[0]
-  def helper = new TestHelper()
-
-  pipeline {
-    agent none
-
-    options {
-      buildDiscarder(logRotator(artifactNumToKeepStr:'40'))
-    }
-
-    parameters {
-      choice(choices: ["", "quiet", "info", "warn", "debug"], description: 'Choose the log level', name: 'LOG_LEVEL')
-      booleanParam(defaultValue: false, description: 'Whether to log truncated stacktraces', name: 'STACK_TRACE')
-      booleanParam(defaultValue: false, description: 'Whether to refresh dependencies', name: 'REFRESH_DEPENDENCIES')
-      booleanParam(defaultValue: false, description: 'Whether to force sonarqube execution', name: 'RUN_SONAR')
-    }
-
-    stages {
-
-      stage("check") {
-        agent any
-
-        when {
-          anyOf {
-            changeset comparator: 'GLOB', pattern: 'atlas-jenkins-pipeline-gradle/**'
-            isRestartedRun()
-            triggeredBy 'UserIdCause'
-          }
-        }
-
-        steps {
-          script {
-            def stepsForParallel = platforms.collectEntries { platform ->
-              def environment = []
-              def labels = config.labels
-
-              if(config.testEnvironment) {
-                if(config.testEnvironment instanceof List) {
-                  environment = config.testEnvironment
+def call(Map configMap = [:]) {
+    javaLibs(configMap) { stages ->
+        stages.check = { check, params, config ->
+            check.when = {
+                anyOf {
+                    changeset comparator: 'GLOB', pattern: 'atlas-jenkins-pipeline-gradle/**'
+                    isRestartedRun()
+                    triggeredBy 'UserIdCause'
                 }
-                else {
-                  environment = (config.testEnvironment[platform]) ?: []
-                }
-              }
-
-              environment << "COVERALLS_PARALLEL=true"
-
-              if(config.testLabels) {
-                if(config.testLabels instanceof List) {
-                  labels = config.testLabels
-                }
-                else {
-                  labels = (config.testLabels[platform]) ?: config.labels
-                }
-              }
-
-              def testConfig = config.clone()
-              testConfig.labels = labels
-
-              def checkStep = {
-                dir("atlas-jenkins-pipeline-gradle") {
-                    withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'ATLAS_GITHUB_INTEGRATION_PASSWORD', usernameVariable: 'ATLAS_GITHUB_INTEGRATION_USER')]) {
-                        gradleWrapper "check"
-                    }
-                }
-              }
-              def finalizeStep = {
-                dir("atlas-jenkins-pipeline-gradle") {
-                  if(!currentBuild.result) {
-                    def tasks  = "jacocoTestReport"
-                    if(config.sonarToken && (BRANCH_NAME =~ config.sonarQubeBranchPattern || params.RUN_SONAR)) {
-                      tasks += " sonarqube -Dsonar.login=${config.sonarToken}"
-                    }
-                    withEnv(["COVERALLS_REPO_TOKEN=${config.coverallsToken}"]) {
-                      gradleWrapper tasks
-                      publishHTML([
-                                allowMissing: true,
-                                alwaysLinkToLastBuild: true,
-                                keepAll: true,
-                                reportDir: 'build/reports/jacoco/test/html',
-                                reportFiles: 'index.html',
-                                reportName: "Coverage ${it}",
-                                reportTitles: ''
-                                ])
-                    }
-                  }
-                }
-                junit allowEmptyResults: true, testResults: "**/build/test-results/**/*.xml"
-                //cleanWs()
-              }
-
-              ["check ${platform}" : helper.transformIntoCheckStep(platform, environment, config.coverallsToken, testConfig, checkStep, finalizeStep)]
             }
-
-            parallel stepsForParallel
-          }
         }
-     }
+
+        stages.publish = { publish, params, config ->
+            publish.when = { false }
+        }
     }
-  }
 }
 
-call(plaforms: ['unix'])
+call(plaforms: ['unix'], checkDir: "atlas-jenkins-pipeline-gradle")

--- a/atlas-jenkins-pipeline-gradle/Jenkinsfile
+++ b/atlas-jenkins-pipeline-gradle/Jenkinsfile
@@ -1,22 +1,24 @@
 #!groovy
-@Library('github.com/wooga/atlas-jenkins-pipeline@detach/test-lib') _
+@Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 def call(Map configMap = [:]) {
-    javaLibs(configMap) { stages ->
-        stages.check = { check, params, config ->
-            check.when = {
-                anyOf {
-                    changeset comparator: 'GLOB', pattern: 'atlas-jenkins-pipeline-gradle/**'
-                    isRestartedRun()
-                    triggeredBy 'UserIdCause'
+    withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'ATLAS_GITHUB_INTEGRATION_PASSWORD', usernameVariable: 'ATLAS_GITHUB_INTEGRATION_USER')]) {
+        javaLibs(configMap) { stages ->
+            stages.check = { check, params, config ->
+                check.when = {
+                    anyOf {
+                        changeset comparator: 'GLOB', pattern: 'atlas-jenkins-pipeline-gradle/**'
+                        isRestartedRun()
+                        triggeredBy 'UserIdCause'
+                    }
                 }
             }
-        }
 
-        stages.publish = { publish, params, config ->
-            publish.when = { false }
+            stages.publish = { publish, params, config ->
+                publish.when = { false }
+            }
         }
     }
 }
 
-call(plaforms: ['unix'], checkDir: "atlas-jenkins-pipeline-gradle")
+call(platforms: ['macos'], checkDir: "atlas-jenkins-pipeline-gradle")

--- a/atlas-jenkins-pipeline-gradle/Jenkinsfile
+++ b/atlas-jenkins-pipeline-gradle/Jenkinsfile
@@ -1,24 +1,6 @@
 #!groovy
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-def call(Map configMap = [:]) {
-    withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'ATLAS_GITHUB_INTEGRATION_PASSWORD', usernameVariable: 'ATLAS_GITHUB_INTEGRATION_USER')]) {
-        javaLibs(configMap) { stages ->
-            stages.check = { check, params, config ->
-                check.when = {
-                    anyOf {
-                        changeset comparator: 'GLOB', pattern: 'atlas-jenkins-pipeline-gradle/**'
-                        isRestartedRun()
-                        triggeredBy 'UserIdCause'
-                    }
-                }
-            }
-
-            stages.publish = { publish, params, config ->
-                publish.when = { false }
-            }
-        }
-    }
+withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'ATLAS_GITHUB_INTEGRATION_PASSWORD', usernameVariable: 'ATLAS_GITHUB_INTEGRATION_USER')]) {
+    buildLocalGradlePlugin(platforms: ['macos'], checkDir: "atlas-jenkins-pipeline-gradle")
 }
-
-call(platforms: ['macos'], checkDir: "atlas-jenkins-pipeline-gradle")

--- a/atlas-jenkins-pipeline-gradle/build.gradle
+++ b/atlas-jenkins-pipeline-gradle/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'groovy'
-    id 'java-gradle-plugin'
-    id 'jacoco'
+    id "net.wooga.plugins-local" version "4.0.0"
 }
 
 group = 'com.wooga'
@@ -29,85 +27,5 @@ gradlePlugin {
 
 dependencies {
     implementation 'org.ajoberstar.grgit:grgit-core:[4,5)'
-    implementation 'org.codehaus.groovy:groovy-all:2.5.12'
-    testImplementation 'com.github.stefanbirkner:system-rules:[1,2)'
-    testImplementation platform("org.spockframework:spock-bom:1.2-groovy-2.4")
-    testImplementation "org.spockframework:spock-core"
     testImplementation 'com.wooga.spock.extensions:spock-github-extension:0.2.0'
-    testImplementation ('com.netflix.nebula:nebula-test:[8,9)') {
-        version {
-            strictly '8.1.0'
-        }
-    }
-}
-
-//////////////////////////////////////////////
-// This will be provided by a custom plugin //
-//////////////////////////////////////////////
-
-setupIntegrationTestTask(project, tasks)
-configureJacocoTestReport(project, tasks.integrationTest, tasks.test)
-
-private static Test setupIntegrationTestTask(final Project project, final TaskContainer tasks) {
-    JavaPluginConvention javaConvention = project.getConvention().getPlugins().get("java") as JavaPluginConvention
-
-    def integrationTestSourceSet = setupIntegrationTestSourceSet(project, javaConvention)
-    setupIntegrationTestConfiguration(project, javaConvention)
-
-    Test integrationTestTask = tasks.create(name: "integrationTest", type: Test) as Test
-
-    integrationTestTask.with {
-        setTestClassesDirs(integrationTestSourceSet.output.classesDirs)
-        classpath = integrationTestSourceSet.runtimeClasspath
-        outputs.upToDateWhen { false }
-    }
-
-    def checkLifeCycleTask = tasks.getByName("check")
-    checkLifeCycleTask.dependsOn integrationTestTask
-
-    def testTask = tasks.getByName("test")
-    integrationTestTask.mustRunAfter testTask
-
-    integrationTestTask
-}
-
-private static void setupIntegrationTestConfiguration(Project project, final JavaPluginConvention javaConvention) {
-    def test = javaConvention.sourceSets.getByName("test")
-    def integrationTest = javaConvention.sourceSets.getByName("integrationTest")
-
-    test.implementationConfigurationName
-    def configurations = project.configurations
-    def testImplementation = configurations.getByName(test.implementationConfigurationName)
-    def testRuntimeOnly = configurations.getByName(test.runtimeOnlyConfigurationName)
-
-    def integrationTestImplementation = configurations.getByName(integrationTest.implementationConfigurationName)
-    integrationTestImplementation.extendsFrom(testImplementation)
-
-    def integrationTestRuntimeOnly = configurations.getByName(integrationTest.runtimeOnlyConfigurationName)
-    integrationTestRuntimeOnly.extendsFrom(testRuntimeOnly)
-}
-
-private static SourceSet setupIntegrationTestSourceSet(final Project project, final JavaPluginConvention javaConvention) {
-    def main = javaConvention.sourceSets.getByName("main")
-    def test = javaConvention.sourceSets.getByName("test")
-
-    SourceSet sourceSet = javaConvention.sourceSets.maybeCreate("integrationTest")
-    sourceSet.setCompileClasspath(project.files(main.compileClasspath, test.compileClasspath, sourceSet.compileClasspath))
-    sourceSet.setRuntimeClasspath(project.files(main.compileClasspath, test.compileClasspath, sourceSet.runtimeClasspath))
-
-    sourceSet.groovy.srcDir("src/" + sourceSet.getName() + "/groovy");
-    sourceSet.resources.srcDir("src/" + sourceSet.getName() + "/resources");
-    sourceSet
-}
-
-private static configureJacocoTestReport(final Project project, final Task integrationTestTask, Task testTask) {
-    project.tasks.withType(JacocoReport) { JacocoReport jacocoReport ->
-        if (jacocoReport.name == "jacoco" + JavaPlugin.TEST_TASK_NAME.capitalize() + "Report") {
-            jacocoReport.reports{ JacocoReportsContainer configurableReports ->
-                configurableReports.xml.enabled = true
-                configurableReports.html.enabled = true
-            }
-            jacocoReport.executionData(integrationTestTask, testTask)
-        }
-    }
 }

--- a/vars/buildLocalGradlePlugin.groovy
+++ b/vars/buildLocalGradlePlugin.groovy
@@ -1,0 +1,28 @@
+#!/usr/bin/env groovy
+
+import net.wooga.jenkins.pipeline.config.JavaConfig
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                                                    //
+// Step buildGradlePlugin                                                                                             //
+//                                                                                                                    //
+//                                                                                                                    //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+def call(Map configMap = [:]) {
+    def checkDir = configMap.checkDir?: "."
+    javaLibs(configMap) { stages ->
+        stages.check = { check, params, config ->
+            check.when = {
+                anyOf {
+                    changeset comparator: 'GLOB', pattern: "${checkDir}/**"
+                    isRestartedRun()
+                    triggeredBy 'UserIdCause'
+                }
+            }
+        }
+        stages.publish = { publish, params, JavaConfig config ->
+            publish.when = { false }
+        }
+    }
+}

--- a/vars/buildLocalGradlePlugin.txt
+++ b/vars/buildLocalGradlePlugin.txt
@@ -1,0 +1,14 @@
+Custom step to build and test local gradle plugins.
+
+usage:
+
+```
+def coveralls_token = "coveralls token" //can be null
+
+def testEnvironment = [
+                        "test_var_1=value1",
+                        "test_var_2=value2"
+                       ]
+
+buildLocalGradlePlugin plaforms: ['macos'], coverallsToken: coveralls_token, testEnvironment: testEnvironment, checkDir: "my-project-gradle"
+```


### PR DESCRIPTION
## Description
Adds new pipeline for local plugin project tests, `vars/buildLocalGradlePlugin.groovy`. Its set to be triggered whenever a change in a given `checkDirectory` is passed through, and then runs in the same framework as the other java libraries (`vars/javaLibs.groovy`), except it never publishes anything. If `checkDirectory` is empty it will assume that the git root is the location of the local project.

This new pipeline was tested and is applied in this repository local plugin `atlas-jenkins-pipeline-gradle`. This PR also updates the local plugin `build.gradle` file to use the lastest version of `atlas-plugins`.

## Changes
* ![ADD] `buildLocalGradlePlugin` pipeline for testing local gradle plugin projects.
* ![IMPROVE] uses `buildLocalGradlePlugin` pipeline in `atlas-jenkins-pipeline-gradle
* ![UPDATE] updates `atlas-jenkins-pipeline-gradle` to the latest `atlas-plugins` local plugin version.




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
