### PR TITLE
Adds snyk env vars to javaLibs

### DIFF
--- a/vars/javaLibs.groovy
+++ b/vars/javaLibs.groovy
@@ -26,6 +26,12 @@ def call(Map configMap = [:], Closure stepsConfigCls) {
       buildDiscarder(logRotator(artifactNumToKeepStr:'40'))
     }
 
+    environment {
+      SNYK_TOKEN = credentials("atlas_plugins_snyk_token")
+      SNYK_AUTO_DOWNLOAD = "YES"
+      SNYK_ORG_NAME = "wooga-pipeline"
+    }
+
     parameters {
       choice(choices: ["snapshot", "rc", "final"], description: 'Choose the distribution type', name: 'RELEASE_TYPE')
       choice(choices: ["", "patch", "minor", "major"], description: 'Choose the change scope', name: 'RELEASE_SCOPE')


### PR DESCRIPTION
## Description
Adds Snyk env vars to all java libraries/gradle plugins pipelines. Please note that these variables still need the snyk gradle plugin in order to be effective.

## Changes
* ![ADD] Snyk enviromnent variables to all java libraries/gradle plugins pipelines




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
