### PR TITLE
Add withUnityLicenseCredentials

### DIFF
--- a/vars/withSecretEnv.groovy
+++ b/vars/withSecretEnv.groovy
@@ -1,0 +1,9 @@
+#!/usr/bin/env groovy
+
+def call(List<Map> varAndPasswordList, Closure closure) {
+  wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: varAndPasswordList]) {
+    withEnv(varAndPasswordList.collect { "${it.var}=${it.password}" }) {
+      closure()
+    }
+  }
+}

--- a/vars/withUnityLicenseCredentials.groovy
+++ b/vars/withUnityLicenseCredentials.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/env groovy
+
+def call(String credentialsId, Closure closure) {
+  withCredentials([string(credentialsId: credentialsId, variable: 'SECRET')]) {
+  	withSecretEnv([
+            	[var: 'UNITY_AUTHENTICATION_USERNAME', password: jsonKey(SECRET, 'username')],
+            	[var: 'UNITY_PWD', password: jsonKey(SECRET, 'password')],
+            	[var: 'UNITY_AUTHENTICATION_SERIAL', password: jsonKey(SECRET, 'serial')]
+    ]) {
+    	closure()
+  	}
+  }
+}
+
+String jsonKey(String json, String key) {
+	def obj = readJSON text: json
+	obj[key]
+}

--- a/vars/withUnityLicenseCredentials.txt
+++ b/vars/withUnityLicenseCredentials.txt
@@ -1,0 +1,23 @@
+Short hand to use Unity license credentials on atlas-unity incovations
+
+credentials of format:
+
+{ 
+    "username" : "some_user@domain.com",
+    "password" : "some_password",
+    "serial" : "SB-XXXX-XXXX-XXXX-XXXX-XXXX"
+}
+
+get mapped to environment variables (from atlas-unity gradle plugin):
+UNITY_AUTHENTICATION_USERNAME, UNITY_PWD, UNITY_AUTHENTICATION_SERIAL
+
+
+Arguments:
+
+- crendentialsId // jenkins credentials id (could be a AWS credential)
+
+Usage:
+
+withUnityLicenseCredentials("my_credentials_id") {
+    // your_unity_invocation
+}


### PR DESCRIPTION
## Description

Short hand to use Unity license credentials on atlas-unity incovations

credentials of format:

```json
{ 
    "username" : "some_user@domain.com",
    "password" : "some_password",
    "serial" : "SB-XXXX-XXXX-XXXX-XXXX-XXXX"
}
```
get mapped to environment variables (from atlas-unity gradle plugin):
`UNITY_AUTHENTICATION_USERNAME`, `UNITY_PWD`, `UNITY_AUTHENTICATION_SERIAL`

Usage can be seen in this [WDKSandbox example](https://github.com/wooga/atlas-unity-WDKSandbox/pull/30)
## Changes
* ![ADD] add `withUnityLicenseCredentials`

[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
