### PR TITLE
Converts all exceptions to base Exception class

### DIFF
--- a/atlas-jenkins-pipeline-test/src/main/groovy/net/wooga/jenkins/pipeline/test/specifications/SandboxedDeclarativeJenkinsSpec.groovy
+++ b/atlas-jenkins-pipeline-test/src/main/groovy/net/wooga/jenkins/pipeline/test/specifications/SandboxedDeclarativeJenkinsSpec.groovy
@@ -7,7 +7,7 @@ import net.wooga.jenkins.pipeline.test.sandbox.SandboxPipelineTestHelper
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.GenericWhitelist
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist
-
+//TODO check this out: https://github.com/jenkinsci/script-security-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
 abstract class SandboxedDeclarativeJenkinsSpec extends DeclarativeJenkinsSpec {
 
 

--- a/src/net/wooga/jenkins/pipeline/BuildVersion.groovy
+++ b/src/net/wooga/jenkins/pipeline/BuildVersion.groovy
@@ -16,7 +16,7 @@ class BuildVersion {
      */
     static BuildVersion parse(Object unityVerObj) {
         if(unityVerObj == null){
-            throw new IllegalArgumentException("Entry cannot be null")
+            throw new Exception("Entry cannot be null")
         }
         if (unityVerObj instanceof Closure) {
             return parse(unityVerObj())
@@ -32,7 +32,7 @@ class BuildVersion {
 
     static BuildVersion fromBuildVersionMap(Map unityVerMap) {
         if(unityVerMap["version"] == null) {
-            throw new IllegalArgumentException("Entry ${unityVerMap} does not contain version")
+            throw new Exception("Entry ${unityVerMap} does not contain version")
         }
         String version = unityVerMap["version"]
         boolean optional = unityVerMap["optional"]?: false

--- a/src/net/wooga/jenkins/pipeline/config/BaseConfig.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/BaseConfig.groovy
@@ -1,7 +1,5 @@
 package net.wooga.jenkins.pipeline.config
 
-import net.wooga.jenkins.pipeline.PipelineTools
-
 class BaseConfig {
     final Object jenkins
     final PipelineConventions conventions

--- a/src/net/wooga/jenkins/pipeline/config/JenkinsMetadata.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/JenkinsMetadata.groovy
@@ -8,7 +8,7 @@ class JenkinsMetadata {
 
     static JenkinsMetadata fromScript(Object jenkinsScript) {
         if(jenkinsScript.BUILD_NUMBER == null) {
-            throw new IllegalStateException("Jenkins script object must have a BUILD_NUMBER property")
+            throw new Exception("Jenkins script object must have a BUILD_NUMBER property")
         }
         def envMap = jenkinsScript.env?: [:]
         return new JenkinsMetadata(

--- a/src/net/wooga/jenkins/pipeline/config/Platform.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/Platform.groovy
@@ -150,6 +150,6 @@ class Platform {
         if(obj instanceof Collection) {
             return obj as Collection
         }
-        throw new IllegalArgumentException("${obj} should be a Collection or a Map of [key:collection] or [key:string]")
+        throw new Exception("${obj} should be a Collection or a Map of [key:collection] or [key:string]")
     }
 }

--- a/src/net/wooga/jenkins/pipeline/config/WDKConfig.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/WDKConfig.groovy
@@ -22,7 +22,7 @@ class WDKConfig implements PipelineConfig {
     static WDKConfig fromConfigMap(String buildLabel, Map configMap, Object jenkinsScript) {
         configMap.unityVersions = configMap.unityVersions ?: []
         def unityVersions = collectUnityVersions(configMap.unityVersions as List, buildLabel, configMap)
-        if (unityVersions.isEmpty()) throw new IllegalArgumentException("Please provide at least one unity version.")
+        if (unityVersions.isEmpty()) throw new Exception("Please provide at least one unity version.")
 
         def baseConfig = BaseConfig.fromConfigMap(configMap, jenkinsScript)
 

--- a/test/groovy/net/wooga/jenkins/pipeline/config/BuildVersionSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/BuildVersionSpec.groovy
@@ -36,7 +36,7 @@ class BuildVersionSpec extends Specification {
         when:
         BuildVersion.parse(obj)
         then:
-        def e = thrown(IllegalArgumentException)
+        def e = thrown(Exception)
         e.message == message
         where:
         obj              | message

--- a/test/groovy/net/wooga/jenkins/pipeline/config/JenkinsMetadataSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/JenkinsMetadataSpec.groovy
@@ -31,7 +31,7 @@ class JenkinsMetadataSpec extends Specification {
         JenkinsMetadata.fromScript(propsObj)
 
         then:
-        def e = thrown(IllegalStateException)
+        def e = thrown(Exception)
         e.message == "Jenkins script object must have a BUILD_NUMBER property"
     }
 

--- a/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
@@ -43,7 +43,7 @@ class WDKConfigSpec extends Specification {
         when:
         WDKConfig.fromConfigMap("any", [unityVersions: unityVersions], new FakeJenkinsObject([:]))
         then:
-        def e = thrown(IllegalArgumentException)
+        def e = thrown(Exception)
         e.message == "Please provide at least one unity version."
 
         where:


### PR DESCRIPTION
## Description
The jenkins sandbox strikes again. This time, it doesn't accepts exceptions like `IllegalArgumentException`or `IllegalStateException`, only accepting the base `Exception`and `MalformedURLException` for some reason. 

All exception types were converted to `Exception` to avoid this.

## Changes
* ![CHANGE] All exception types changed to `Exception`




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
