### PR TITLE
Fixes --refresh-dependencies being glued to task name

### DIFF
--- a/src/net/wooga/jenkins/pipeline/model/Gradle.groovy
+++ b/src/net/wooga/jenkins/pipeline/model/Gradle.groovy
@@ -52,7 +52,7 @@ class Gradle {
             result += " --stacktrace"
         }
         if(refreshDependencies && !containsOptions(result, "refresh-dependencies")) {
-            result += "--refresh-dependencies"
+            result += " --refresh-dependencies"
         }
 
         return result

--- a/test/groovy/scripts/BuildWDKAutoSwitchSpec.groovy
+++ b/test/groovy/scripts/BuildWDKAutoSwitchSpec.groovy
@@ -117,7 +117,7 @@ class BuildWDKAutoSwitchSpec extends DeclarativeJenkinsSpec {
             calls.has["sh"] { MethodCall call ->
                 String args = call.args[0]["script"]
                 args.contains("gradlew") &&
-                args.contains("--refresh-dependencies")
+                args.contains(" --refresh-dependencies")
             }
         }
         Map env = binding.env

--- a/test/groovy/scripts/GradleWrapperSpec.groovy
+++ b/test/groovy/scripts/GradleWrapperSpec.groovy
@@ -27,8 +27,8 @@ class GradleWrapperSpec extends DeclarativeJenkinsSpec {
         callString.contains("gradlew")
         callString.contains(command)
         containsArgIf(callString, logLevel, "--${logLevel}".toString())
-        containsArgIf(callString, stackTrace, "--stacktrace")
-        containsArgIf(callString, refreshDependencies, "--refresh-dependencies")
+        containsArgIf(callString, stackTrace, " --stacktrace")
+        containsArgIf(callString, refreshDependencies, " --refresh-dependencies")
 
         where:
         command | logLevel | stackTrace | refreshDependencies


### PR DESCRIPTION
## Description

`--refresh-dependencies` was being added to gradle cmd string without spaces. Added that space.

## Changes
* ![FIX] `--refresh-dependencies` not working properly


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
