### PR TITLE
WDK pipeline doesn't generate extra steps for optional/different net standard checks

### DIFF
--- a/src/net/wooga/jenkins/pipeline/check/WDKChecks.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/WDKChecks.groovy
@@ -38,7 +38,7 @@ class WDKChecks {
     Map<String, Closure> parallel(UnityVersionPlatform[] wdkPlatforms, Step checkStep,
                                   PipelineConventions conventions = PipelineConventions.standard) {
         return wdkPlatforms.collectEntries { wdkPlatform ->
-            [("${conventions.wdkParallelPrefix}${wdkPlatform.platform.name}".toString()): checkStep.pack(wdkPlatform.platform)]
+            [("${conventions.wdkParallelPrefix}${wdkPlatform.stepDescription}".toString()): checkStep.pack(wdkPlatform.platform)]
         }
     }
 
@@ -51,7 +51,7 @@ class WDKChecks {
                                   PipelineConventions conventions = PipelineConventions.standard) {
         return wdkPlatforms.collectEntries { wdkPlatform ->
             def checkStep = checkCreator.csWDKChecks(wdkPlatform, testStep, analysisStep)
-            return [("${conventions.wdkParallelPrefix}${wdkPlatform.platform.name}".toString()): checkStep]
+            return [("${conventions.wdkParallelPrefix}${wdkPlatform.stepDescription}".toString()): checkStep]
         }
     }
 

--- a/src/net/wooga/jenkins/pipeline/config/PipelineConventions.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/PipelineConventions.groovy
@@ -44,7 +44,7 @@ class PipelineConventions implements Cloneable {
     String setupTask = "setup"
 
     String javaParallelPrefix = "check "
-    String wdkParallelPrefix = "check Unity-"
+    String wdkParallelPrefix = "check "
     String wdkCoberturaFile = '**/codeCoverage/Cobertura.xml'
     String wdkSetupStashId = 'setup_w'
 }


### PR DESCRIPTION
## Description
The WDK pipeline wasn't generating extra steps for multiple unity platform entries with the same version but different options (stuff like optional and API compatiblity level). That was due to a naming error when generating the parallel map. Now we are using the right name on parallel steps, and the adequate tests were added so that this bug is not introduced again

## Changes
* ![FIX] WDK pipeline didn't generate extra steps for optional/different net standard checks




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
