### PR TITLE
Adds support to UMASK environment variable on gradle wrapper

### DIFF
--- a/src/net/wooga/jenkins/pipeline/model/Gradle.groovy
+++ b/src/net/wooga/jenkins/pipeline/model/Gradle.groovy
@@ -36,6 +36,19 @@ class Gradle {
         }
     }
 
+    def wrapper(String umask, String command, Boolean returnStatus = false,
+                Boolean returnStdout = false) {
+        if (jenkins.isUnix()) {
+            if(umask != null && umask != "") {
+                def numericUmask = umask.replaceAll("[^\\d]", "")
+                return jenkins.sh(script: "umask $numericUmask && ./gradlew ${formatCommand(command)}", returnStdout: returnStdout, returnStatus: returnStatus)
+            }
+            return jenkins.sh(script: "./gradlew ${formatCommand(command)}", returnStdout: returnStdout, returnStatus: returnStatus)
+        } else {
+            return jenkins.bat(script: "gradlew.bat ${formatCommand(command)}", returnStdout: returnStdout, returnStatus: returnStatus)
+        }
+    }
+
     /**
      * @param command
      * @return A formatted command for the gradle process. If a log level was provided by the

--- a/vars/gradleWrapper.groovy
+++ b/vars/gradleWrapper.groovy
@@ -9,5 +9,5 @@ def call(String command, Boolean returnStatus = false, Boolean returnStdout = fa
                 params.LOG_LEVEL?: env.LOG_LEVEL as String,
                 params.STACK_TRACE? params.STACK_TRACE as Boolean : false,
                 params.REFRESH_DEPENDENCIES? params.REFRESH_DEPENDENCIES as Boolean : false)
-    gradle.wrapper(command, returnStatus, returnStdout)
+    gradle.wrapper(env.UMASK as String, command, returnStatus, returnStdout)
 }


### PR DESCRIPTION
## Description
Adds support for custom umask values when executing gradle through `gradleWrapper`. Is umask a new food? No. https://en.wikipedia.org/wiki/Umask

This is needed due to a limitation on NFS that impedes us to set ACM for its folders, and this together with some UID inconsistencies between jenkins agents, makes that sometimes files are checked out with wrong permissions.


## Changes
* ![ADD] Umask support to `gradleWrapper`.




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
