### PR TITLE
Add explicit defaults for RELEASE_TYPE and RELEASE_SCOPE

### DIFF
--- a/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
+++ b/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
@@ -17,8 +17,8 @@ class Publishers {
     Publishers(Object jenkinsScript, Gradle gradle, String releaseType, String releaseScope) {
         this.jenkins = jenkinsScript
         this.gradle = gradle
-        this.releaseScope = releaseScope.trim()
-        this.releaseType = releaseType.trim()
+        this.releaseScope = releaseScope?.trim()?: "snapshot"
+        this.releaseType = releaseType?.trim() ?: ""
     }
 
     def gradlePlugin(String publishKeySecret, String publishSecretSecret,

--- a/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
+++ b/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
@@ -17,8 +17,8 @@ class Publishers {
     Publishers(Object jenkinsScript, Gradle gradle, String releaseType, String releaseScope) {
         this.jenkins = jenkinsScript
         this.gradle = gradle
-        this.releaseScope = releaseScope?.trim()?: "snapshot"
-        this.releaseType = releaseType?.trim() ?: ""
+        this.releaseType = releaseType?.trim()
+        this.releaseScope = releaseScope?.trim()
     }
 
     def gradlePlugin(String publishKeySecret, String publishSecretSecret,

--- a/test/groovy/scripts/BuildUnityWdkV2Spec.groovy
+++ b/test/groovy/scripts/BuildUnityWdkV2Spec.groovy
@@ -26,13 +26,13 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
         then: "runs gradle with parameters"
         assertShCallsWith("gradlew",
                 "publish",
-                "-Ppaket.publish.repository='${releaseType}'",
-                "-Ppublish.repository='${releaseType}'",
-                "-PversionBuilder.stage=${releaseType}",
-                "-PversionBuilder.scope=${releaseScope}"
+                "-Ppaket.publish.repository='${releaseType?:"snapshot"}'",
+                "-Ppublish.repository='${releaseType?:"snapshot"}'",
+                "-PversionBuilder.stage=${releaseType?:"snapshot"}",
+                "-PversionBuilder.scope=${releaseScope?:""}"
         )
         and: "has set up environment"
-        def env = usedEnvironments[usedEnvironments.size()-2]
+        def env = usedEnvironments[usedEnvironments.size() - 2]
         hasBaseEnvironment(env, "level")
         env.GRGIT == this.credentials['github_access']
         env.GRGIT_USER == "usr" //"${GRGIT_USR}"
@@ -47,6 +47,7 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
 
         where:
         releaseType | releaseScope
+        null        | null
         "snapshot"  | "patch"
         "preflight" | "minor"
         "rc"        | "minor"
@@ -81,7 +82,7 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
         env.UPM_USER_CONFIG_FILE == upmCredsFile.absolutePath
 
         and: "stashes gradle cache and build outputs"
-        stash['wdk_output']["includes"] ==".gradle/**, **/build/outputs/**/*"
+        stash['wdk_output']["includes"] == ".gradle/**, **/build/outputs/**/*"
 
         where:
         releaseType | releaseScope
@@ -107,7 +108,7 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
         }
 
         then: "runs gradle with parameters"
-        assertShCallsWith(2,"gradlew", //2 calls 1 for upm, 1 for paket
+        assertShCallsWith(2, "gradlew", //2 calls 1 for upm, 1 for paket
                 "-Prelease.stage=${releaseType}",
                 "-Prelease.scope=${releaseScope}",
                 "setup")
@@ -150,11 +151,11 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
         }
 
         then: "all workspaces are clean"
-        calls["cleanWs"].length == (clearWs? 4 : 0) //setup, build, hash, and publish steps
+        calls["cleanWs"].length == (clearWs ? 4 : 0) //setup, build, hash, and publish steps
 
         where:
         clearWs << [true, false]
-        description = clearWs? "clears" : "doesn't clear"
+        description = clearWs ? "clears" : "doesn't clear"
     }
 
     def hasBaseEnvironment(Map env, String logLevel) {

--- a/test/groovy/tools/GradleInvocation.groovy
+++ b/test/groovy/tools/GradleInvocation.groovy
@@ -1,0 +1,41 @@
+package tools
+
+class GradleInvocation {
+
+    static def parseCommandLine(String cmdGradleCall) {
+        def elements = cmdGradleCall.split(" ")
+                .collect {it.trim()}
+                .findAll{ it != null & !it.empty }
+                .findAll{!(it.endsWith("gradlew") || it.endsWith("gradlew.bat")) }
+        def propertiesRaw = elements.findAll{it.startsWith("-P") }
+        def properties = propertiesRaw.collectEntries {raw ->
+            def parts = raw.split("=")
+            def key = parts[0].replaceAll("-P","").trim()
+            def value = parts.size() > 1? parts[1] : null
+            return [(key): value]
+        } as Map<String, String>
+
+        def tasks = elements.findAll {!it.startsWith("-") }
+
+        return new GradleInvocation(cmdGradleCall, tasks, properties)
+    }
+
+    String raw
+    String[] tasks
+    Map<String, String> properties
+
+    GradleInvocation(String raw, List<String> tasks, Map<String, String> properties) {
+        this.raw = raw
+        this.tasks = tasks
+        this.properties = properties
+    }
+
+    def getAt(String propertyKey) {
+        return properties[propertyKey]
+    }
+
+    boolean containsRaw(String s) {
+        return raw.contains(s)
+    }
+}
+

--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -13,7 +13,7 @@ def call(Map configMap = [:]) {
     javaLibs(configMap) { stages ->
         stages.publish = { stage, params, JavaConfig config ->
             stage.action = {
-                def publisher = config.pipelineTools.createPublishers(params.RELEASE_TYPE, params.RELEASE_SCOPE)
+                def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
                 publisher.gradlePlugin('gradle.publish.key', 'gradle.publish.secret')
             }
         }

--- a/vars/buildJavaLibrary.groovy
+++ b/vars/buildJavaLibrary.groovy
@@ -12,7 +12,7 @@ def call(Map configMap = [:]) {
     javaLibs(configMap) { stages ->
         stages.publish = { stage, params, JavaConfig config ->
             stage.action = {
-                def publisher = config.pipelineTools.createPublishers(params.RELEASE_TYPE, params.RELEASE_SCOPE)
+                def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
                 publisher.bintray('bintray.publish')
             }
         }

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -13,7 +13,7 @@ def call(Map configMap = [:]) {
     javaLibs(configMap) { stages ->
         stages.publish = { stage, params, JavaConfig config ->
             stage.action = {
-                def publisher = config.pipelineTools.createPublishers(params.RELEASE_TYPE, params.RELEASE_SCOPE)
+                def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
                 publisher.ossrh('ossrh.publish', 'ossrh.signing.key',
                             'ossrh.signing.key_id', 'ossrh.signing.passphrase')
             }

--- a/vars/buildPrivateGradlePlugin.groovy
+++ b/vars/buildPrivateGradlePlugin.groovy
@@ -13,7 +13,7 @@ def call(Map configMap = [:]) {
         stages.publish = { stage, params, JavaConfig config ->
             stage.when = { true } //always
             stage.action = {
-                def publisher = config.pipelineTools.createPublishers(params.RELEASE_TYPE, params.RELEASE_SCOPE)
+                def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
                 publisher.artifactoryOSSRH('artifactory_publish',
                             'ossrh.signing.key',
                             'ossrh.signing.key_id',

--- a/vars/buildPrivateJavaLibrary.groovy
+++ b/vars/buildPrivateJavaLibrary.groovy
@@ -13,7 +13,7 @@ def call(Map configMap = [:]) {
         stages.publish = { stage, params, JavaConfig config ->
             stage.when = { true } //always
             stage.action = {
-                def publisher = config.pipelineTools.createPublishers(params.RELEASE_TYPE, params.RELEASE_SCOPE)
+                def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
                 publisher.artifactoryOSSRH('artifactory_publish',
                             'ossrh.signing.key',
                             'ossrh.signing.key_id',

--- a/vars/buildWDKJS.groovy
+++ b/vars/buildWDKJS.groovy
@@ -51,6 +51,10 @@ def call(Map configMap = [:]) {
             stage('Preparation') {
                 agent any
                 steps {
+                    script {
+                        env.RELEASE_TYPE = params.RELEASE_TYPE?: "snapshot"
+                        env.RELEASE_SCOPE = params.RELEASE_SCOPE?: ""
+                    }
                     sendSlackNotification "STARTED", true
                 }
             }
@@ -59,7 +63,7 @@ def call(Map configMap = [:]) {
                 when {
                     beforeAgent true
                     expression {
-                        return params.RELEASE_TYPE == "snapshot"
+                        return env.RELEASE_TYPE == "snapshot"
                     }
                 }
 
@@ -87,7 +91,7 @@ def call(Map configMap = [:]) {
                 when {
                     beforeAgent true
                     expression {
-                        return params.RELEASE_TYPE != "snapshot" || params.BUILD_ARTIFACTS
+                        return env.RELEASE_TYPE != "snapshot" || params.BUILD_ARTIFACTS
                     }
                 }
 
@@ -97,7 +101,7 @@ def call(Map configMap = [:]) {
 
                 steps {
                     script {
-                        def publisher = config.pipelineTools.createPublishers(params.RELEASE_TYPE, params.RELEASE_SCOPE)
+                        def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
                         publisher.npm('atlas_npm_credentials')
                     }
                 }


### PR DESCRIPTION
## Description

Adds explicit default values for `RELEASE_TYPE` and `RELEASE_SCOPE` parameters, because jenkins doesn't set any parameters on first pipeline run, and this may lead to issues in the publish step.

This was done by setting new envs RELEASE_TYPE and RELEASE_SCOPE in the setup step, because the `params` map provided by jenkins was immutable. 

There are a bunch of changes, but most of them are repetitive so, don't be intimidated :)
 

## Changes
* ![FIX] Pipelines breaking on publish if in first jenkins run.




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
