### PR TITLE
Fix testEnvironment being evaluated outside of agent node

### DIFF
--- a/src/net/wooga/jenkins/pipeline/check/EnclosureCreator.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/EnclosureCreator.groovy
@@ -14,14 +14,14 @@ class EnclosureCreator {
     }
 
     Closure withNodeAndEnv(Platform platform, PackedStep mainCls, Closure catchCls, PackedStep finallyCls) {
-        def testEnvironment = platform.testEnvironment +
-                ["TRAVIS_JOB_NUMBER=${buildNumber}.${platform.name.toUpperCase()}"]
         return {
             def platformLabels = platform.generateTestLabelsString()
             def nodeLabels = platformLabels && !platformLabels.empty ?
                     "atlas && ${platform.generateTestLabelsString()}" : "atlas"
             jenkins.node(nodeLabels) {
                 jenkins.echo("Running on: ${jenkins.env.NODE_NAME}")
+                def testEnvironment = platform.testEnvironment +
+                        ["TRAVIS_JOB_NUMBER=${buildNumber}.${platform.name.toUpperCase()}"]
                 jenkins.withEnv(testEnvironment) {
                     try {
                         mainCls.call()


### PR DESCRIPTION
## Description
`testEnvironment` closures weren't being evaluated in the agent node context, as they should, so they can access node-specific environment. Moved its evaluation to inside the node.

## Changes
* ![FIX] move testEnvironment evaluation to inside agent node.
...




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
