### PR TITLE
Add workingDir convention

### DIFF
--- a/atlas-jenkins-pipeline-gradle/src/integrationTest/groovy/net/wooga/jenkins/VersionPluginIntegrationSpec.groovy
+++ b/atlas-jenkins-pipeline-gradle/src/integrationTest/groovy/net/wooga/jenkins/VersionPluginIntegrationSpec.groovy
@@ -33,15 +33,7 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
 
     @Unroll("creates/updates remote branches and tags when updating from #latestVersion to #newVersion")
     def "should create generic branches and tags with updated version remotely"(String newVersion, String latestVersion, String[] branches, String updateType) {
-        given: "a initialized git repository and latest version with its branches and tag"
-        def git = initializeGrGit("origin")
-        createRemoteBranchesIfNotExists(branches)
-        def latestTag = createTagIfNotExists(git, latestVersion)
-        latestTag.ifPresent { git.push(remote: "origin", tags: true) }
-        git.fetch()
-
-
-        and: "loaded version plugin"
+        given: "loaded version plugin"
         buildFile << """
             ${applyPlugin(VersionPlugin)}
         """
@@ -52,6 +44,15 @@ class VersionPluginIntegrationSpec extends IntegrationSpec {
             remote = "origin"
             updateType = "${updateType}"
         }"""
+
+        and: "a initialized git repository and latest version with its branches and tag"
+        def git = initializeGrGit("origin")
+        createRemoteBranchesIfNotExists(branches)
+        def latestTag = createTagIfNotExists(git, latestVersion)
+        latestTag.ifPresent { git.push(remote: "origin", tags: true) }
+        git.fetch()
+
+
 
         and: "credentials in the environment"
         environment.set("GRGIT_USER", this.githubRepo.userName)

--- a/src/net/wooga/jenkins/pipeline/assemble/Assemblers.groovy
+++ b/src/net/wooga/jenkins/pipeline/assemble/Assemblers.groovy
@@ -1,5 +1,6 @@
 package net.wooga.jenkins.pipeline.assemble
 
+import net.wooga.jenkins.pipeline.config.PipelineConventions
 import net.wooga.jenkins.pipeline.model.Gradle
 
 class Assemblers {
@@ -16,11 +17,15 @@ class Assemblers {
         this.gradle = gradle
     }
 
-    def unityWDK(String unityLogCategory, String releaseType, String releaseScope) {
-        jenkins.withEnv(["UNITY_LOG_CATEGORY = ${unityLogCategory}"]) {
-            gradle.wrapper("-Prelease.stage=${releaseType.trim()} -Prelease.scope=${releaseScope.trim()} assemble")
+    def unityWDK(String unityLogCategory, String releaseType, String releaseScope,
+                 PipelineConventions conventions = PipelineConventions.standard) {
+        String workingDir = conventions.workingDir
+        jenkins.dir(workingDir) {
+            jenkins.withEnv(["UNITY_LOG_CATEGORY = ${unityLogCategory}"]) {
+                gradle.wrapper("-Prelease.stage=${releaseType.trim()} -Prelease.scope=${releaseScope.trim()} assemble")
+            }
         }
-        return jenkins.findFiles(glob: 'build/outputs/*.nupkg')[0]
+        return jenkins.findFiles(glob: "$workingDir/build/outputs/*.nupkg")[0]
     }
 
 }

--- a/src/net/wooga/jenkins/pipeline/check/JSChecks.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/JSChecks.groovy
@@ -24,8 +24,9 @@ class JSChecks {
                 baseAnalysisStep.wrappedBy(checkArgs.analysisWrapper), conventions)
     }
 
-    Closure check(Platform platform, Step testStep, Step analysisStep) {
-        return checkCreator.junitCheck(platform, testStep, analysisStep)
+    Closure check(Platform platform, Step testStep, Step analysisStep,
+                  PipelineConventions conventions = PipelineConventions.standard) {
+        return checkCreator.junitCheck(conventions.workingDir, platform, testStep, analysisStep)
     }
 
     Map<String, Closure> parallel(Platform[] platforms, Closure checkStep,
@@ -47,7 +48,7 @@ class JSChecks {
                                   PipelineConventions conventions = PipelineConventions.standard) {
         return platforms.collectEntries { platform ->
             String parallelStepName = "${conventions.javaParallelPrefix}${platform.name}"
-            return [(parallelStepName): check(platform, testStep, analysisStep)]
+            return [(parallelStepName): check(platform, testStep, analysisStep, conventions)]
         }
     }
 }

--- a/src/net/wooga/jenkins/pipeline/check/JavaChecks.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/JavaChecks.groovy
@@ -33,12 +33,12 @@ class JavaChecks {
                                   PipelineConventions conventions = PipelineConventions.standard) {
         return platforms.collectEntries { platform ->
             String parallelStepName = "${conventions.javaParallelPrefix}${platform.name}"
-            return [(parallelStepName): check(platform, testStep, analysisStep)]
+            return [(parallelStepName): check(platform, testStep, analysisStep, conventions)]
         }
     }
 
-    Closure check(Platform platform, Step testStep, Step analysisStep) {
-        return checkCreator.junitCheck(platform, testStep, analysisStep)
+    Closure check(Platform platform, Step testStep, Step analysisStep, PipelineConventions conventions = PipelineConventions.standard) {
+        return checkCreator.junitCheck(conventions.workingDir, platform, testStep, analysisStep)
     }
 
     Map<String, Closure> gradleCheckWithCoverage(Platform[] platforms, CheckArgs checkArgs, PipelineConventions conventions) {

--- a/src/net/wooga/jenkins/pipeline/check/WDKChecks.groovy
+++ b/src/net/wooga/jenkins/pipeline/check/WDKChecks.groovy
@@ -26,8 +26,9 @@ class WDKChecks {
                         conventions)
     }
 
-    Closure check(UnityVersionPlatform platform, Step testStep, Step analysisStep) {
-        return checkCreator.csWDKChecks(platform, testStep, analysisStep)
+    Closure check(UnityVersionPlatform platform, Step testStep, Step analysisStep,
+                  PipelineConventions conventions = PipelineConventions.standard) {
+        return checkCreator.csWDKChecks(conventions.workingDir, platform, testStep, analysisStep)
     }
 
     Map<String, Closure> parallel(UnityVersionPlatform[] wdkPlatforms, Closure checkStep,
@@ -50,7 +51,7 @@ class WDKChecks {
     Map<String, Closure> parallel(UnityVersionPlatform[] wdkPlatforms, Step testStep, Step analysisStep,
                                   PipelineConventions conventions = PipelineConventions.standard) {
         return wdkPlatforms.collectEntries { wdkPlatform ->
-            def checkStep = checkCreator.csWDKChecks(wdkPlatform, testStep, analysisStep)
+            def checkStep = checkCreator.csWDKChecks(conventions.workingDir, wdkPlatform, testStep, analysisStep)
             return [("${conventions.wdkParallelPrefix}${wdkPlatform.stepDescription}".toString()): checkStep]
         }
     }

--- a/src/net/wooga/jenkins/pipeline/config/PipelineConventions.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/PipelineConventions.groovy
@@ -20,6 +20,7 @@ class PipelineConventions implements Cloneable {
         this.javaParallelPrefix = other.javaParallelPrefix
         this.wdkParallelPrefix = other.wdkParallelPrefix
         this.wdkCoberturaFile = other.wdkCoberturaFile
+        this.workingDir = other.workingDir
     }
 
     PipelineConventions mergeWithConfigMap(Map configMap) {
@@ -33,6 +34,7 @@ class PipelineConventions implements Cloneable {
             it.wdkParallelPrefix = configMap.wdkParallelPrefix?: it.wdkParallelPrefix
             it.wdkCoberturaFile = configMap.wdkCoberturaFile?: it.wdkCoberturaFile
             it.wdkSetupStashId = configMap.wdkSetupStashId?: it.wdkSetupStashId
+            it.workingDir = configMap.workingDir?: it.workingDir
             return it
         }
     }
@@ -47,6 +49,8 @@ class PipelineConventions implements Cloneable {
     String wdkParallelPrefix = "check "
     String wdkCoberturaFile = '**/codeCoverage/Cobertura.xml'
     String wdkSetupStashId = 'setup_w'
+
+    String workingDir = '.'
 }
 
 class ImmutablePipelineConventions extends PipelineConventions {

--- a/src/net/wooga/jenkins/pipeline/config/Platform.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/Platform.groovy
@@ -19,7 +19,7 @@ class Platform {
     static Platform forJava(String platformName, Map config, boolean isMain) {
         return new Platform(
                 (config.checkoutDir?: ".") as String,
-                (config.checkDir?: config.workingDir?: ".") as String,
+                (config.checkDir?: ".") as String,
                 platformName,
                 platformName,
                 platformName == "linux",
@@ -34,7 +34,7 @@ class Platform {
     static Platform forJS(String platformName, Map config, boolean isMain) {
         return new Platform(
                 (config.checkoutDir?: ".") as String,
-                (config.checkDir?: config.workingDir?: ".") as String,
+                (config.checkDir?: ".") as String,
                 platformName,
                 platformName,
                 platformName == "linux",
@@ -56,7 +56,7 @@ class Platform {
         }
         return new Platform(
                 (config.checkoutDir?: buildVersion.toDirectoryName()) as String,
-                (config.checkDir?: config.workingDir?: ".") as String,
+                (config.checkDir?: ".") as String,
                 buildVersion.version,
                 buildVersion.label,
                 false,

--- a/src/net/wooga/jenkins/pipeline/config/Platform.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/Platform.groovy
@@ -19,7 +19,7 @@ class Platform {
     static Platform forJava(String platformName, Map config, boolean isMain) {
         return new Platform(
                 (config.checkoutDir?: ".") as String,
-                (config.checkDir?: ".") as String,
+                (config.checkDir?: config.workingDir?: ".") as String,
                 platformName,
                 platformName,
                 platformName == "linux",
@@ -34,7 +34,7 @@ class Platform {
     static Platform forJS(String platformName, Map config, boolean isMain) {
         return new Platform(
                 (config.checkoutDir?: ".") as String,
-                (config.checkDir?: ".") as String,
+                (config.checkDir?: config.workingDir?: ".") as String,
                 platformName,
                 platformName,
                 platformName == "linux",
@@ -56,7 +56,7 @@ class Platform {
         }
         return new Platform(
                 (config.checkoutDir?: buildVersion.toDirectoryName()) as String,
-                (config.checkDir?: ".") as String,
+                (config.checkDir?: config.workingDir?: ".") as String,
                 buildVersion.version,
                 buildVersion.label,
                 false,

--- a/src/net/wooga/jenkins/pipeline/setup/Setups.groovy
+++ b/src/net/wooga/jenkins/pipeline/setup/Setups.groovy
@@ -18,9 +18,14 @@ class Setups {
         return new Setups(jenkinsScript, gradle)
     }
 
-    def wdk(String releaseType, String releaseScope, String setupTask = PipelineConventions.standard.setupTask) {
-        gradle.wrapper("-Prelease.stage=${releaseType.trim()} " +
-                        "-Prelease.scope=${releaseScope.trim()} ${setupTask}")
+    def wdk(String releaseType, String releaseScope, PipelineConventions conventions = PipelineConventions.standard) {
+        String setupTask = conventions.setupTask
+        String workingDir = conventions.workingDir
+        jenkins.dir(workingDir) {
+            gradle.wrapper("-Prelease.stage=${releaseType.trim()} " +
+                    "-Prelease.scope=${releaseScope.trim()} ${setupTask}")
+        }
+
     }
 
 }

--- a/test/groovy/scripts/BuildWDKJSSpec.groovy
+++ b/test/groovy/scripts/BuildWDKJSSpec.groovy
@@ -142,10 +142,10 @@ class BuildWDKJSSpec extends DeclarativeJenkinsSpec {
         given: "loaded check in a running jenkins build"
         def buildWDKJS = loadSandboxedScript(SCRIPT_PATH)
         and: "configuration object with any platforms"
-        def configMap = [platforms: ["linux"],
-                         sonarToken: "token", coverallsToken: "token",
-                         checkTask: convCheck, sonarqubeTask: convSonarqubeTask,
-                         jacocoTask: convJacocoTask, javaParallelPrefix: convJavaParallelPrefix,
+        def configMap = [platforms    : ["linux"],
+                         sonarToken   : "token", coverallsToken: "token",
+                         checkTask    : convCheck, sonarqubeTask: convSonarqubeTask,
+                         jacocoTask   : convJacocoTask, javaParallelPrefix: convJavaParallelPrefix,
                          coverallsTask: convCoverallsTask]
 
         when: "running check"
@@ -180,9 +180,9 @@ class BuildWDKJSSpec extends DeclarativeJenkinsSpec {
         and: "configuration object with any platforms and desired wrappers"
 
         def configMap = [
-                platforms: ["linux", "windows"],
-                sonarToken: "token", coverallsToken: "token",
-                testWrapper: { testOp, platform ->
+                platforms      : ["linux", "windows"],
+                sonarToken     : "token", coverallsToken: "token",
+                testWrapper    : { testOp, platform ->
                     testCount.incrementAndGet()
                     testOp(platform)
                 },
@@ -238,23 +238,25 @@ class BuildWDKJSSpec extends DeclarativeJenkinsSpec {
         checkoutDir << [".", "dir", "dir/subdir"]
     }
 
-    @Unroll("runs test and analysis step on #checkDir")
+    @Unroll("runs test and analysis step on #checkoutDir/#checkDir/#workingDir")
     def "runs test and analysis step on given checkDir"() {
         given: "loaded check in a running jenkins build"
         def buildWDKJS = loadSandboxedScript(SCRIPT_PATH)
         and: "configuration object with any platforms and wrappers for test result capture"
         def stepsDirs = []
-        def checkoutDir = "."
-        def configMap = [platforms: ["linux"], checkDir: checkDir,
-                         checkoutDir: checkoutDir,
-                         testWrapper: { testOp, platform ->
-                             stepsDirs.add(this.currentDir)
-                             testOp(platform)
-                         },
-                         analysisWrapper: { analysisOp, platform ->
-                             stepsDirs.add(this.currentDir)
-                             analysisOp(platform)
-                         }]
+        def configMap = [
+                platforms      : ["linux"],
+                checkDir       : checkDir,
+                workingDir     : workingDir,
+                checkoutDir    : checkoutDir,
+                testWrapper    : { testOp, platform ->
+                    stepsDirs.add(this.currentDir)
+                    testOp(platform)
+                },
+                analysisWrapper: { analysisOp, platform ->
+                    stepsDirs.add(this.currentDir)
+                    analysisOp(platform)
+                }]
 
         when: "running check"
         inSandbox {
@@ -265,10 +267,18 @@ class BuildWDKJSSpec extends DeclarativeJenkinsSpec {
         then: "steps ran on given directory"
         //checks steps + 1 analysis step
         stepsDirs.size() == configMap.platforms.size() + 1
-        stepsDirs.every {it == "${checkoutDir}/${checkDir}"}
+        stepsDirs.each {
+            assert it == "${checkoutDir}/${checkDir}/${workingDir}"
+        }
 
         where:
-        checkDir << [".", "dir", "dir/subdir"]
+        checkoutDir | checkDir     | workingDir
+        "."         | "."          | "."
+        "."         | "dir"        | "."
+        "."         | "dir/subdir" | "."
+        "checkout"  | "dir/subdir" | "."
+        "checkout"  | "dir/subdir" | "working"
+        "."         | "."          | "working"
     }
 
     @Unroll("#description all check workspaces when clearWs is #clearWs")
@@ -283,15 +293,15 @@ class BuildWDKJSSpec extends DeclarativeJenkinsSpec {
         }
 
         then: "all platforms workspaces are clean"
-        calls["cleanWs"].length == (clearWs? platforms.size() : 0)
+        calls["cleanWs"].length == (clearWs ? platforms.size() : 0)
 
         where:
-        platforms | clearWs
-        ["linux"] | true
-        ["linux"] | false
+        platforms            | clearWs
+        ["linux"]            | true
+        ["linux"]            | false
         ["linux", "windows"] | true
         ["linux", "windows"] | false
-        description = clearWs? "clears" : "doesn't clear"
+        description = clearWs ? "clears" : "doesn't clear"
     }
 //    jenkins.usernamePassword(credentialsId: npmCredsSecret,
 //    usernameVariable:"NODE_RELEASE_NPM_USER",
@@ -318,7 +328,7 @@ class BuildWDKJSSpec extends DeclarativeJenkinsSpec {
         skipsRelease ^ gradleCall.contains("-Prelease.scope=${releaseScope}")
         skipsRelease ^ gradleCall.contains("-x check")
         and: "sets credentials on environment"
-        def env =  usedEnvironments.last()
+        def env = usedEnvironments.last()
         skipsRelease ^ env["NODE_RELEASE_NPM_USER"] == "npmusr"
         skipsRelease ^ env["NODE_RELEASE_NPM_PASS"] == "npmpwd"
 

--- a/test/groovy/scripts/JavaCheckSpec.groovy
+++ b/test/groovy/scripts/JavaCheckSpec.groovy
@@ -236,11 +236,11 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         given: "loaded check in a running jenkins build"
         def check = loadSandboxedScript(TEST_SCRIPT_PATH)
         and: "configuration object with any platforms"
-        def configMap = [platforms: ["linux"],
-                        sonarToken: "token", coverallsToken: "token",
-                        checkTask: convCheck, sonarqubeTask: convSonarqubeTask,
-                        jacocoTask: convJacocoTask, javaParallelPrefix: convJavaParallelPrefix,
-                        coverallsTask: convCoverallsTask]
+        def configMap = [platforms    : ["linux"],
+                         sonarToken   : "token", coverallsToken: "token",
+                         checkTask    : convCheck, sonarqubeTask: convSonarqubeTask,
+                         jacocoTask   : convJacocoTask, javaParallelPrefix: convJavaParallelPrefix,
+                         coverallsTask: convCoverallsTask]
 
         when: "running check"
         Map<String, ?> checkSteps = inSandbox {
@@ -285,16 +285,16 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         and: "configuration object with any platforms and desired wrappers"
 
         def configMap = [
-            platforms: ["linux", "windows"],
-            sonarToken: "token", coverallsToken: "token",
-            testWrapper: { testOp, platform ->
-                testCount.incrementAndGet()
-                testOp(platform)
-            },
-            analysisWrapper: { analysisOp, platform ->
-                analysisCount.incrementAndGet()
-                analysisOp(platform)
-            }
+                platforms      : ["linux", "windows"],
+                sonarToken     : "token", coverallsToken: "token",
+                testWrapper    : { testOp, platform ->
+                    testCount.incrementAndGet()
+                    testOp(platform)
+                },
+                analysisWrapper: { analysisOp, platform ->
+                    analysisCount.incrementAndGet()
+                    analysisOp(platform)
+                }
         ]
 
         when: "running check"
@@ -352,17 +352,19 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         def check = loadSandboxedScript(TEST_SCRIPT_PATH)
         and: "configuration object with any platforms and wrappers for test result capture"
         def stepsDirs = []
-        def checkoutDir = "."
-        def configMap = [platforms: ["linux"], checkDir: checkDir,
-            checkoutDir: checkoutDir,
-            testWrapper: { testOp, platform ->
-                stepsDirs.add(this.currentDir)
-                testOp(platform)
+        def configMap = [
+                platforms      : ["linux"],
+                checkoutDir    : checkoutDir,
+                checkDir       : checkDir,
+                workingDir     : workingDir,
+                testWrapper    : { testOp, platform ->
+                    stepsDirs.add(this.currentDir)
+                    testOp(platform)
                 },
-            analysisWrapper: { analysisOp, platform ->
-                stepsDirs.add(this.currentDir)
-                analysisOp(platform)
-            }]
+                analysisWrapper: { analysisOp, platform ->
+                    stepsDirs.add(this.currentDir)
+                    analysisOp(platform)
+                }]
 
         when: "running check"
         inSandbox {
@@ -373,10 +375,16 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         then: "steps ran on given directory"
         //checks steps + 1 analysis step
         stepsDirs.size() == configMap.platforms.size() + 1
-        stepsDirs.every {it == "${checkoutDir}/${checkDir}"}
+        stepsDirs.every { it == "${checkoutDir}/${checkDir}/${workingDir}" }
 
         where:
-        checkDir << [".", "dir", "dir/subdir"]
+        checkoutDir | checkDir     | workingDir
+        "."         | "."          | "."
+        "."         | "dir"        | "."
+        "."         | "dir/subdir" | "."
+        "checkout"  | "dir/subdir" | "."
+        "checkout"  | "dir/subdir" | "working"
+        "."         | "."          | "working"
     }
 
     @Unroll("#description all check workspaces when clearWs is #clearWs")
@@ -391,15 +399,15 @@ class JavaCheckSpec extends DeclarativeJenkinsSpec {
         }
 
         then: "all platforms workspaces are clean"
-        calls["cleanWs"].length == (clearWs? platforms.size() : 0)
+        calls["cleanWs"].length == (clearWs ? platforms.size() : 0)
 
         where:
-        platforms | clearWs
-        ["linux"] | true
-        ["linux"] | false
+        platforms            | clearWs
+        ["linux"]            | true
+        ["linux"]            | false
         ["linux", "windows"] | true
         ["linux", "windows"] | false
-        description = clearWs? "clears" : "doesn't clear"
+        description = clearWs ? "clears" : "doesn't clear"
     }
 
     static def createTmpFile(String dir = ".", String file) {

--- a/vars/buildGradlePlugin.groovy
+++ b/vars/buildGradlePlugin.groovy
@@ -14,7 +14,7 @@ def call(Map configMap = [:]) {
         stages.publish = { stage, params, JavaConfig config ->
             stage.action = {
                 def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
-                publisher.gradlePlugin('gradle.publish.key', 'gradle.publish.secret')
+                publisher.gradlePlugin('gradle.publish.key', 'gradle.publish.secret', config.conventions)
             }
         }
     }

--- a/vars/buildJavaLibrary.groovy
+++ b/vars/buildJavaLibrary.groovy
@@ -13,7 +13,7 @@ def call(Map configMap = [:]) {
         stages.publish = { stage, params, JavaConfig config ->
             stage.action = {
                 def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
-                publisher.bintray('bintray.publish')
+                publisher.bintray('bintray.publish', config.conventions)
             }
         }
     }

--- a/vars/buildJavaLibraryOSSRH.groovy
+++ b/vars/buildJavaLibraryOSSRH.groovy
@@ -15,7 +15,7 @@ def call(Map configMap = [:]) {
             stage.action = {
                 def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
                 publisher.ossrh('ossrh.publish', 'ossrh.signing.key',
-                            'ossrh.signing.key_id', 'ossrh.signing.passphrase')
+                            'ossrh.signing.key_id', 'ossrh.signing.passphrase', config.conventions)
             }
         }
     }

--- a/vars/buildPrivateGradlePlugin.groovy
+++ b/vars/buildPrivateGradlePlugin.groovy
@@ -17,7 +17,7 @@ def call(Map configMap = [:]) {
                 publisher.artifactoryOSSRH('artifactory_publish',
                             'ossrh.signing.key',
                             'ossrh.signing.key_id',
-                        'ossrh.signing.passphrase')
+                        'ossrh.signing.passphrase', config.conventions)
             }
         }
     }

--- a/vars/buildPrivateJavaLibrary.groovy
+++ b/vars/buildPrivateJavaLibrary.groovy
@@ -17,7 +17,7 @@ def call(Map configMap = [:]) {
                 publisher.artifactoryOSSRH('artifactory_publish',
                             'ossrh.signing.key',
                             'ossrh.signing.key_id',
-                        'ossrh.signing.passphrase')
+                        'ossrh.signing.passphrase', config.conventions)
             }
         }
     }

--- a/vars/buildUnityWdkV2.groovy
+++ b/vars/buildUnityWdkV2.groovy
@@ -74,7 +74,7 @@ def call(Map configMap = [unityVersions: []]) {
                 env.RELEASE_STAGE = params.RELEASE_STAGE?: defaultReleaseType
                 env.RELEASE_SCOPE = params.RELEASE_SCOPE?: defaultReleaseScope
                 def setup = config.pipelineTools.setups
-                setup.wdk(env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
+                setup.wdk(env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String, config.conventions)
               }
             }
             post {
@@ -109,7 +109,7 @@ def call(Map configMap = [unityVersions: []]) {
                 env.RELEASE_STAGE = params.RELEASE_STAGE?: defaultReleaseType
                 env.RELEASE_SCOPE = params.RELEASE_SCOPE?: defaultReleaseScope
                 def setup = config.pipelineTools.setups
-                setup.wdk(env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
+                setup.wdk(env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String, config.conventions)
               }
             }
             post {
@@ -176,7 +176,7 @@ def call(Map configMap = [unityVersions: []]) {
               unstash 'upm_setup_w'
               script {
                 def assembler = config.pipelineTools.assemblers
-                assembler.unityWDK("build", env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
+                assembler.unityWDK("build", env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String, config.conventions)
               }
             }
 
@@ -244,7 +244,7 @@ def call(Map configMap = [unityVersions: []]) {
           unstash 'wdk_output'
           script {
             def publisher = config.pipelineTools.createPublishers(env.RELEASE_STAGE, env.RELEASE_SCOPE)
-            publisher.unityArtifactoryUpm('artifactory_publish')
+            publisher.unityArtifactoryUpm('artifactory_publish', config.conventions)
           }
         }
 


### PR DESCRIPTION
## Description
Adds a new parameter to the pipeline configuration: `workingDir`. It allows you to set the current directory for all pipeline stages. On checks, this directory is relative to `$checkoutDir\$checkDir`. On other steps, its relative to the workspace root. 

Internally it is set to a new convention field in `PipelineConventions` and can be passed as parameter to methods relating to different steps. 

This PR also fixes bug in a inner plugin test that shown up kinda out of nowhere?

## Changes
* ![ADD] new `workingDir` configuration to pipeline configuration.




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
