### PR TITLE
Can now change gradle calls environment

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/net/wooga/jenkins/pipeline/assemble/Assemblers.groovy
+++ b/src/net/wooga/jenkins/pipeline/assemble/Assemblers.groovy
@@ -20,7 +20,7 @@ class Assemblers {
         jenkins.withEnv(["UNITY_LOG_CATEGORY = ${unityLogCategory}"]) {
             gradle.wrapper("-Prelease.stage=${releaseType.trim()} -Prelease.scope=${releaseScope.trim()} assemble")
         }
-        return jenkins.findFiles(glob: 'build/outputs/*.nupkg')[0]
+        def artifacts = jenkins.findFiles(glob: 'build/outputs/*.nupkg')
+        return artifacts? artifacts[0] : null
     }
-
 }

--- a/src/net/wooga/jenkins/pipeline/config/GradleArgs.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/GradleArgs.groovy
@@ -1,21 +1,26 @@
 package net.wooga.jenkins.pipeline.config
 
+import net.wooga.jenkins.pipeline.model.EnvVars
 import net.wooga.jenkins.pipeline.model.Gradle
 
 class GradleArgs {
 
+    final EnvVars environment
     final String logLevel
     final boolean stackTrace
     final boolean refreshDependencies
 
 
     static GradleArgs fromConfigMap(Map config) {
-        def showStackTraces = (config.showStackTrace?:false) as boolean
-        def refreshDependencies = (config.refreshDependencies?:false) as boolean
-        return new GradleArgs(config.logLevel as String, showStackTraces, refreshDependencies)
+        def environment = new EnvVars((config.gradleEnvironment ?: [:]) as Map<String, ?>)
+        def showStackTraces = (config.showStackTrace ?: false) as boolean
+        def refreshDependencies = (config.refreshDependencies ?: false) as boolean
+        return new GradleArgs(environment, config.logLevel as String, showStackTraces, refreshDependencies)
     }
 
-    GradleArgs(String logLevel, boolean stackTrace, boolean refreshDependencies) {
+
+    GradleArgs(EnvVars environment, String logLevel, boolean stackTrace, boolean refreshDependencies) {
+        this.environment = environment
         this.logLevel = logLevel
         this.stackTrace = stackTrace
         this.refreshDependencies = refreshDependencies

--- a/src/net/wooga/jenkins/pipeline/config/GradleArgs.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/GradleArgs.groovy
@@ -12,7 +12,7 @@ class GradleArgs {
 
 
     static GradleArgs fromConfigMap(Map config) {
-        def environment = new EnvVars((config.gradleEnvironment ?: [:]) as Map<String, ?>)
+        def environment = EnvVars.fromList((config.gradleEnvironment ?: []) as List<?>)
         def showStackTraces = (config.showStackTrace ?: false) as boolean
         def refreshDependencies = (config.refreshDependencies ?: false) as boolean
         return new GradleArgs(environment, config.logLevel as String, showStackTraces, refreshDependencies)

--- a/src/net/wooga/jenkins/pipeline/model/EnvVars.groovy
+++ b/src/net/wooga/jenkins/pipeline/model/EnvVars.groovy
@@ -1,0 +1,40 @@
+package net.wooga.jenkins.pipeline.model
+
+class EnvVars {
+
+    final Map<String, Closure<String>> environment
+
+    EnvVars(Map<String, ?> environment) {
+        this.environment = lazifyMap(environment)
+    }
+
+    static Map<String, Closure<String>> lazifyMap(Map<String, ?> env) {
+        Map<String, Closure<String>> lazyMap = [:]
+        for(String key : env.keySet()) {
+            if(env[key] instanceof Closure) {
+                lazyMap.put(key, env[key])
+            } else {
+                def value = env.get(key)
+                lazyMap.put(key, { -> value })
+            }
+        }
+        return lazyMap
+    }
+
+    List<String> resolveAsStrings() {
+        List<String> result = []
+        for(String key : environment.keySet()) {
+            Closure<String> lazyValue = environment[key]
+            def value = lazyValue?.call()
+            if(value != null) {
+                result += ["$key=$value"]
+            }
+        }
+        return result
+    }
+
+    Closure<String> getAt(String key) {
+        environment[key]
+    }
+
+}

--- a/src/net/wooga/jenkins/pipeline/model/EnvVars.groovy
+++ b/src/net/wooga/jenkins/pipeline/model/EnvVars.groovy
@@ -27,9 +27,10 @@ class EnvVars {
     }
 
     Object getAt(String key) {
-        environment.collect{resolveString(it).split("=")}.find{
+        environment.collect{envEntry ->
+            resolveString(envEntry).split("=")}.find{
             it[0] == key
-        }
+        }?.getAt(1)
     }
 
 }

--- a/test/groovy/net/wooga/jenkins/pipeline/config/GradleArgsSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/GradleArgsSpec.groovy
@@ -26,13 +26,12 @@ class GradleArgsSpec extends Specification {
 
         where:
         env            | logLevel | stackTrace | refreshDeps | expected
-        [:]            | null     | null       | null        | new GradleArgs(new EnvVars([:]), null, false, false)
-        [:]            | "info"   | false      | false       | new GradleArgs(new EnvVars([:]), "info", false, false)
-        [:]            | "quiet"  | true       | false       | new GradleArgs(new EnvVars([:]), "quiet", true, false)
-        [:]            | "quiet"  | false      | true        | new GradleArgs(new EnvVars([:]), "quiet", false, true)
-        [:]            | "quiet"  | false      | true        | new GradleArgs(new EnvVars([:]), "quiet", false, true)
-        [:]            | "quiet"  | false      | true        | new GradleArgs(new EnvVars([:]), "quiet", false, true)
-        [env: "value"] | "quiet"  | false      | true        | new GradleArgs(new EnvVars([env: "value"]), "quiet", false, true)
+        [:]            | null     | null       | null        | new GradleArgs(EnvVars.fromList([]), null, false, false)
+        [:]            | "info"   | false      | false       | new GradleArgs(EnvVars.fromList([]), "info", false, false)
+        [:]            | "quiet"  | true       | false       | new GradleArgs(EnvVars.fromList([]), "quiet", true, false)
+        [:]            | "quiet"  | false      | true        | new GradleArgs(EnvVars.fromList([]), "quiet", false, true)
+        [:]            | "quiet"  | false      | true        | new GradleArgs(EnvVars.fromList([]), "quiet", false, true)
+        [:]            | "quiet"  | false      | true        | new GradleArgs(EnvVars.fromList([]), "quiet", false, true)
+        [env: "value"] | "quiet"  | false      | true        | new GradleArgs(EnvVars.fromList(["env=value"]), "quiet", false, true)
     }
-
 }

--- a/test/groovy/net/wooga/jenkins/pipeline/config/GradleArgsSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/GradleArgsSpec.groovy
@@ -1,5 +1,6 @@
 package net.wooga.jenkins.pipeline.config
 
+import net.wooga.jenkins.pipeline.model.EnvVars
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -8,20 +9,30 @@ class GradleArgsSpec extends Specification {
     @Unroll
     def "creates gradle args from config map"() {
         given: "a gradle args configuration map field"
-        def gradleArgs = [logLevel: logLevel, showStackTrace: stackTrace, refreshDependencies: refreshDeps]
+        def gradleArgs = [
+                gradleEnvironment  : env,
+                logLevel           : logLevel,
+                showStackTrace     : stackTrace,
+                refreshDependencies: refreshDeps]
 
         when: "generating config object from map"
         def config = GradleArgs.fromConfigMap(gradleArgs)
 
         then: "generated config object is valid and matches map values"
         config == expected
+        env.keySet().forEach {key ->
+            assert config.environment.environment[key].call() == env[key]
+        }
 
         where:
-        logLevel | stackTrace | refreshDeps | expected
-        null     | null       | null        | new GradleArgs(null, false, false)
-        "info"   | false      | false       | new GradleArgs("info", false, false)
-        "quiet"  | true       | false       | new GradleArgs("quiet", true, false)
-        "quiet"  | false      | true        | new GradleArgs("quiet", false, true)
+        env            | logLevel | stackTrace | refreshDeps | expected
+        [:]            | null     | null       | null        | new GradleArgs(new EnvVars([:]), null, false, false)
+        [:]            | "info"   | false      | false       | new GradleArgs(new EnvVars([:]), "info", false, false)
+        [:]            | "quiet"  | true       | false       | new GradleArgs(new EnvVars([:]), "quiet", true, false)
+        [:]            | "quiet"  | false      | true        | new GradleArgs(new EnvVars([:]), "quiet", false, true)
+        [:]            | "quiet"  | false      | true        | new GradleArgs(new EnvVars([:]), "quiet", false, true)
+        [:]            | "quiet"  | false      | true        | new GradleArgs(new EnvVars([:]), "quiet", false, true)
+        [env: "value"] | "quiet"  | false      | true        | new GradleArgs(new EnvVars([env: "value"]), "quiet", false, true)
     }
 
 }

--- a/test/groovy/net/wooga/jenkins/pipeline/config/GradleArgsSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/GradleArgsSpec.groovy
@@ -10,7 +10,7 @@ class GradleArgsSpec extends Specification {
     def "creates gradle args from config map"() {
         given: "a gradle args configuration map field"
         def gradleArgs = [
-                gradleEnvironment  : env,
+                gradleEnvironment  : env.collect { "${it.key}=${it.value}"},
                 logLevel           : logLevel,
                 showStackTrace     : stackTrace,
                 refreshDependencies: refreshDeps]
@@ -21,7 +21,7 @@ class GradleArgsSpec extends Specification {
         then: "generated config object is valid and matches map values"
         config == expected
         env.keySet().forEach {key ->
-            assert config.environment.environment[key].call() == env[key]
+            assert config.environment[key] == env[key]
         }
 
         where:

--- a/test/groovy/scripts/BuildUnityWdkV2Spec.groovy
+++ b/test/groovy/scripts/BuildUnityWdkV2Spec.groovy
@@ -89,7 +89,7 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
                 "assemble")
 
         and: "has set up environment"
-        def env = usedEnvironments.first()
+        def env = usedEnvironments.last()
         hasBaseEnvironment(env, "level")
         env.UNITY_LOG_CATEGORY == "build"
         env.UNITY_PACKAGE_MANAGER == "upm"

--- a/test/groovy/scripts/GradleWrapperSpec.groovy
+++ b/test/groovy/scripts/GradleWrapperSpec.groovy
@@ -21,11 +21,11 @@ class GradleWrapperSpec extends DeclarativeJenkinsSpec {
         usedEnvironments.last() == expectedEnv
 
         where:
-        givenEnv                            | expectedEnv
-        [:]                                 | [:]
-        [ENV: "eager", EAGER: "eager"]      | ["ENV": "eager", "EAGER": "eager"]
-        [EAGER: "eager", LAZY: { "lazy" }]  | ["EAGER": "eager", "LAZY": "lazy"]
-        [ENV: { "lazy" }, LAZY: { "lazy" }] | ["ENV": "lazy", "LAZY": "lazy"]
+        givenEnv                          | expectedEnv
+        [:]                               | [:]
+        ["ENV=eager", "EAGER=eager"]      | ["ENV": "eager", "EAGER": "eager"]
+        ["EAGER=eager", { "LAZY=lazy" }]  | ["EAGER": "eager", "LAZY": "lazy"]
+        [{ "ENV=lazy" }, { "LAZY=lazy" }] | ["ENV": "lazy", "LAZY": "lazy"]
     }
 
     @Unroll

--- a/vars/buildUnityWdkV2.groovy
+++ b/vars/buildUnityWdkV2.groovy
@@ -216,8 +216,7 @@ def call(Map configMap = [unityVersions: []]) {
                   withEnv(["UNITY_PACKAGE_MANAGER=upm"]) {
                     parallel checkSteps(config, "upm check unity ", "upm_setup_w")
                   }
-                },
-                failFast : true
+                }
               }
             }
           }

--- a/vars/buildUnityWdkV2.groovy
+++ b/vars/buildUnityWdkV2.groovy
@@ -30,7 +30,6 @@ def call(Map configMap = [unityVersions: []]) {
   }
 
   def config = WDKConfig.fromConfigMap(configMap, this)
-  def packageManagerEnvVar = "UNITY_PACKAGE_MANAGER"
 
   // We can only configure static pipelines atm.
   // To test multiple unity versions we use a script block with a parallel stages inside.

--- a/vars/gradleWrapper.groovy
+++ b/vars/gradleWrapper.groovy
@@ -5,9 +5,9 @@ import net.wooga.jenkins.pipeline.model.Gradle
 /**
  * execute gradlew or gradlew.bat based on current os
  */
-def call(String command, Boolean returnStatus = false, Boolean returnStdout = false, Map<String, ?> environment=[:]) {
+def call(String command, Boolean returnStatus = false, Boolean returnStdout = false, List<?> environment=[]) {
     def gradle = Gradle.fromJenkins(this,
-                new EnvVars(environment),
+                EnvVars.fromList(environment),
                 params.LOG_LEVEL?: env.LOG_LEVEL as String,
                 params.STACK_TRACE? params.STACK_TRACE as Boolean : false,
                 params.REFRESH_DEPENDENCIES? params.REFRESH_DEPENDENCIES as Boolean : false)
@@ -18,7 +18,7 @@ def call(Map args) {
     call(args.command?.toString(),
         (args.returnStatus?: false) as Boolean,
         (args.returnStdout?: false) as Boolean,
-        (args.environment?: [:]) as Map<String, ?>
+        (args.environment?: []) as List<?>
     )
 }
 

--- a/vars/gradleWrapper.groovy
+++ b/vars/gradleWrapper.groovy
@@ -1,13 +1,25 @@
 #!/usr/bin/env groovy
+import net.wooga.jenkins.pipeline.model.EnvVars
 import net.wooga.jenkins.pipeline.model.Gradle
 
 /**
  * execute gradlew or gradlew.bat based on current os
  */
-def call(String command, Boolean returnStatus = false, Boolean returnStdout = false) {
+def call(String command, Boolean returnStatus = false, Boolean returnStdout = false, Map<String, ?> environment=[:]) {
     def gradle = Gradle.fromJenkins(this,
+                new EnvVars(environment),
                 params.LOG_LEVEL?: env.LOG_LEVEL as String,
                 params.STACK_TRACE? params.STACK_TRACE as Boolean : false,
                 params.REFRESH_DEPENDENCIES? params.REFRESH_DEPENDENCIES as Boolean : false)
     gradle.wrapper(env.UMASK as String, command, returnStatus, returnStdout)
 }
+
+def call(Map args) {
+    call(args.command?.toString(),
+        (args.returnStatus?: false) as Boolean,
+        (args.returnStdout?: false) as Boolean,
+        (args.environment?: [:]) as Map<String, ?>
+    )
+}
+
+


### PR DESCRIPTION
## Description
Adds new parameter `gradleEnvironment` that sets environment variables to all gradle calls, like bellow:

```groovy
buildUnityWdkV2 [...], gradleEnvironment: ["VAR=VALUE", { -> "LAZYVAR=LAZYVALUE" }]
```

Also fixes some small bugs with optional unity steps stoping the whole pipeline, and the findFiles steps in setup failing if no file was found. 

## Changes
* ![ADD] Add `gradleEnvironment` parameter
* ![FIX] Unity test step marked as "optional" still stops the whole pipeline
* ![FIX] setup step fails if no nupkg file is found on wdk pipelines.
...




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
