### PR TITLE
Add RW credentials for release builds, add missing properties to pipeline [ATLAS-1559][ATLAS-1566]

### DIFF
--- a/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
+++ b/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
@@ -116,7 +116,9 @@ class Publishers {
                         "-Ppaket.publish.repository='${releaseType}' " +
                         "-Ppublish.repository='${releaseType}' " +
                         "-PversionBuilder.stage=${releaseType} " +
-                        "-PversionBuilder.scope=${releaseScope}")
+                        "-PversionBuilder.scope=${releaseScope}"+
+                        "-Prelease.stage=${releaseType} " +
+                        "-Prelease.scope=${releaseScope}")
             }
         }
     }

--- a/test/groovy/scripts/BuildUnityWdkV2Spec.groovy
+++ b/test/groovy/scripts/BuildUnityWdkV2Spec.groovy
@@ -10,8 +10,10 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
     @Unroll("publishes UPM/Paket WDK #releaseType-#releaseScope release")
     def "publishes UPM/Paket WDK with #release release type"() {
         given: "credentials holder with publish keys"
-        credentials.addUsernamePassword("artifactory_publish", "usr", "pwd")
-        credentials.addUsernamePassword('github_access', "usr", "pwd")
+        credentials.addUsernamePassword("artifactory_publish", "artifactory_publish_usr", "artifactory_publish_pwd")
+        credentials.addUsernamePassword("artifactory_deploy", "artifactory_deploy_usr", "artifactory_deploy_pwd")
+
+        credentials.addUsernamePassword('github_access', "github_access_usr", "github_access_pwd")
         and: "build plugin with publish parameters"
         def buildWDK = loadSandboxedScript(SCRIPT_PATH) {
             params.RELEASE_STAGE = releaseType
@@ -41,9 +43,9 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
         env.GITHUB_PASSWORD == "pwd" //"${GRGIT_PSW}"
         env.UNITY_PACKAGE_MANAGER == "upm"
         env.UNITY_LOG_CATEGORY == "build"
-        env.UPM_USERNAME == "usr" //artifactory_publish user
-        env.UPM_PASSWORD == "pwd" //artifactory_publish password
-        env.NUGET_KEY == this.credentials['artifactory_publish']
+        env.UPM_USERNAME == artifactory_user //artifactory_publish user
+        env.UPM_PASSWORD == artifactory_password //artifactory_publish password
+        env.NUGET_KEY == this.credentials[artifactory_credentials]
 
         where:
         releaseType | releaseScope
@@ -52,6 +54,18 @@ class BuildUnityWdkV2Spec extends DeclarativeJenkinsSpec {
         "preflight" | "minor"
         "rc"        | "minor"
         "final"     | "major"
+
+        github_user = "github_access_usr"
+        github_password = "github_access_pwd"
+        artifactory_deploy_user = "artifactory_deploy_usr"
+        artifactory_deploy_password = "artifactory_deploy_pwd"
+        artifactory_publish_user = "artifactory_publish_usr"
+        artifactory_publish_password = "artifactory_publish_pwd"
+
+        artifactory_user = releaseType == "snapshot" || releaseType == null ? artifactory_publish_user : artifactory_deploy_user
+        artifactory_password = releaseType == "snapshot" || releaseType == null ? artifactory_publish_password : artifactory_deploy_password
+
+        artifactory_credentials = releaseType == "snapshot" || releaseType == null ? "artifactory_publish" : "artifactory_deploy"
     }
 
 

--- a/vars/buildUnityWdkV2.groovy
+++ b/vars/buildUnityWdkV2.groovy
@@ -244,7 +244,7 @@ def call(Map configMap = [unityVersions: []]) {
           unstash 'wdk_output'
           script {
             def publisher = config.pipelineTools.createPublishers(env.RELEASE_STAGE, env.RELEASE_SCOPE)
-            publisher.unityArtifactoryUpm('artifactory_publish')
+            publisher.unityArtifactoryUpm(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish": "artifactory_deploy")
           }
         }
 

--- a/vars/buildWDKAutoSwitch.groovy
+++ b/vars/buildWDKAutoSwitch.groovy
@@ -221,7 +221,7 @@ def call(Map configMap = [ unityVersions:[] ]) {
             def unityPath = "${applicationsHome}/${config.unityVersions[0].stepDescription}/${unityExecPackagePath}"
 
             def publisher = config.pipelineTools.createPublishers(env.RELEASE_TYPE, env.RELEASE_SCOPE)
-            publisher.unityArtifactoryPaket(unityPath, 'artifactory_publish')
+            publisher.unityArtifactoryPaket(unityPath, env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish": "artifactory_deploy")
           }
         }
 


### PR DESCRIPTION
## Description
The publish process for new WDKs is broken as it skips the github release step which also creates the needed version tag in the project. This yields errors the next time a new release is issued. Worse even the old release can be overridden by the next publish. To combat this this PR patches both issues at once. First part is the quick addition of the old legacy properties `release.stage` and `release.scope` These should not be needed anymore but it seems that in some
WDKs the usage is still required. Its easier to fix this here instead of pushing updates through gradle.

The second issue is the publish user. For snapshot builds we need the ability to override versions on jfrog. But that capability is very dangerous for rc or final builds. So we now switch the publish user credentials based on the build release type.

## Changes
* ![ADD] Credentials for final releases
* ![FIX] Missing Properties for backwards compatibility


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
