### PR TITLE
Temporary fix to stop paket to publish dependencies

### DIFF
--- a/atlas-jenkins-pipeline-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/atlas-jenkins-pipeline-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/vars/buildUnityWdkV2.groovy
+++ b/vars/buildUnityWdkV2.groovy
@@ -241,6 +241,9 @@ def call(Map configMap = [unityVersions: []]) {
           unstash 'upm_setup_w'
           unstash 'wdk_output'
           script {
+            // Some packages are shipped with the paket.template, because of it, paket plugin tries to publish those packages.
+            // This is a hack until we implement a better solution (ex: remove the paket.template files when doing paketUnityInstall)
+            sh script: "find Packages -type f -iname \"paket.template\" | xargs rm"
             def publisher = config.pipelineTools.createPublishers(env.RELEASE_STAGE, env.RELEASE_SCOPE)
             publisher.unityArtifactoryUpm(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish": "artifactory_deploy")
           }


### PR DESCRIPTION
## Description
Some dependency packages are being published with the `paket.template` file, which makes the paket publish plugin to publish those. This makes sure that no `paket.template` file exists under the Packages/ folder, so that we can avoid publishing those dependencies.

## Changes
* ![FIX] avoid publishing dependencies in WDK pipelines




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
