### PR TITLE
Add creds for private artifactory in all java-based pipelines

### DIFF
--- a/vars/javaLibs.groovy
+++ b/vars/javaLibs.groovy
@@ -37,6 +37,10 @@ def call(Map configMap = [:], Closure stepsConfigCls) {
       booleanParam(defaultValue: false, description: 'Whether to clear workspaces after build', name: 'CLEAR_WS')
     }
 
+    environment {
+      ATLAS_READ = credentials('artifactory_read') //needed to read private packages
+    }
+
     stages {
       stage('Preparation') {
         agent any


### PR DESCRIPTION
## Description

Add creds for private artifactory in all java-based pipelines

## Changes
* ![ADD] Add creds for private artifactory in all java-based pipelines in javaLibs.groovy

[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
