### PR TITLE
New Pipeline: Wdkv4 - Removes Paket & adds parallel autoref-ed wdks publishing 

### DIFF
--- a/src/net/wooga/jenkins/pipeline/config/WDKConfig.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/WDKConfig.groovy
@@ -6,6 +6,7 @@ class WDKConfig implements PipelineConfig {
 
     final WdkUnityBuildVersion[] unityVersions
     final BaseConfig baseConfig
+    final Boolean autoref
 
     static List<WdkUnityBuildVersion> copyBuildVersionsWithLabels(Map configMap,
                                                                   List<String> labels,
@@ -36,12 +37,15 @@ class WDKConfig implements PipelineConfig {
 
         def baseConfig = BaseConfig.fromConfigMap(configMap, jenkinsScript)
 
-        return new WDKConfig(unityVersions, baseConfig)
+        def autoref = (!configMap.containsKey("autoref")) ? true : configMap.autoref as Boolean
+
+        return new WDKConfig(unityVersions, baseConfig, autoref)
     }
 
-    WDKConfig(List<WdkUnityBuildVersion> unityVersions, BaseConfig baseConfig) {
+    WDKConfig(List<WdkUnityBuildVersion> unityVersions, BaseConfig baseConfig, Boolean autoref) {
         this.unityVersions = unityVersions
         this.baseConfig = baseConfig
+        this.autoref = autoref
     }
 
     @Override

--- a/src/net/wooga/jenkins/pipeline/config/WdkUnityBuildVersion.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/WdkUnityBuildVersion.groovy
@@ -6,11 +6,13 @@ class WdkUnityBuildVersion {
     final Platform platform
     final BuildVersion unityBuildVersion
     final String packageType
+    final String autoref
 
-    WdkUnityBuildVersion(Platform platform, BuildVersion unityBuildVersion, String packageType) {
+    WdkUnityBuildVersion(Platform platform, BuildVersion unityBuildVersion, String packageType, String autoref) {
         this.platform = platform
         this.unityBuildVersion = unityBuildVersion
         this.packageType = packageType
+        this.autoref = autoref
     }
 
     String getVersion() {
@@ -58,8 +60,12 @@ class WdkUnityBuildVersion {
         if (unityVerObj instanceof Map && unityVerObj.containsKey("packageType")) {
             packageType = unityVerObj["packageType"] as String
         }
+        def autoreferenced = "any"
+        if (unityVerObj instanceof Map && unityVerObj.containsKey("autoref")) {
+            autoreferenced = unityVerObj["autoref"]
+        }
         def platform = Platform.forWDK(buildVersion, configMap, isMain)
-        return new WdkUnityBuildVersion(platform, buildVersion, packageType)
+        return new WdkUnityBuildVersion(platform, buildVersion, packageType, autoreferenced)
     }
 
     WdkUnityBuildVersion copy(Map configMap, String label) {
@@ -67,6 +73,7 @@ class WdkUnityBuildVersion {
         new WdkUnityBuildVersion(
                 Platform.forWDK(buildVersion, configMap, false),
                 buildVersion,
-                packageType)
+                packageType,
+                autoref)
     }
 }

--- a/src/net/wooga/jenkins/pipeline/config/WdkUnityBuildVersion.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/WdkUnityBuildVersion.groovy
@@ -6,9 +6,9 @@ class WdkUnityBuildVersion {
     final Platform platform
     final BuildVersion unityBuildVersion
     final String packageType
-    final String autoref
+    final boolean autoref
 
-    WdkUnityBuildVersion(Platform platform, BuildVersion unityBuildVersion, String packageType, String autoref) {
+    WdkUnityBuildVersion(Platform platform, BuildVersion unityBuildVersion, String packageType, boolean autoref) {
         this.platform = platform
         this.unityBuildVersion = unityBuildVersion
         this.packageType = packageType
@@ -60,9 +60,9 @@ class WdkUnityBuildVersion {
         if (unityVerObj instanceof Map && unityVerObj.containsKey("packageType")) {
             packageType = unityVerObj["packageType"] as String
         }
-        def autoreferenced = "any"
+        def autoreferenced = true
         if (unityVerObj instanceof Map && unityVerObj.containsKey("autoref")) {
-            autoreferenced = unityVerObj["autoref"]
+            autoreferenced = unityVerObj["autoref"] as boolean
         }
         def platform = Platform.forWDK(buildVersion, configMap, isMain)
         return new WdkUnityBuildVersion(platform, buildVersion, packageType, autoreferenced)

--- a/src/net/wooga/jenkins/pipeline/config/WdkUnityBuildVersion.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/WdkUnityBuildVersion.groovy
@@ -6,13 +6,11 @@ class WdkUnityBuildVersion {
     final Platform platform
     final BuildVersion unityBuildVersion
     final String packageType
-    final boolean autoref
 
-    WdkUnityBuildVersion(Platform platform, BuildVersion unityBuildVersion, String packageType, boolean autoref) {
+    WdkUnityBuildVersion(Platform platform, BuildVersion unityBuildVersion, String packageType) {
         this.platform = platform
         this.unityBuildVersion = unityBuildVersion
         this.packageType = packageType
-        this.autoref = autoref
     }
 
     String getVersion() {
@@ -60,12 +58,8 @@ class WdkUnityBuildVersion {
         if (unityVerObj instanceof Map && unityVerObj.containsKey("packageType")) {
             packageType = unityVerObj["packageType"] as String
         }
-        def autoreferenced = true
-        if (unityVerObj instanceof Map && unityVerObj.containsKey("autoref")) {
-            autoreferenced = unityVerObj["autoref"] as boolean
-        }
         def platform = Platform.forWDK(buildVersion, configMap, isMain)
-        return new WdkUnityBuildVersion(platform, buildVersion, packageType, autoreferenced)
+        return new WdkUnityBuildVersion(platform, buildVersion, packageType)
     }
 
     WdkUnityBuildVersion copy(Map configMap, String label) {
@@ -73,7 +67,6 @@ class WdkUnityBuildVersion {
         new WdkUnityBuildVersion(
                 Platform.forWDK(buildVersion, configMap, false),
                 buildVersion,
-                packageType,
-                autoref)
+                packageType)
     }
 }

--- a/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
+++ b/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
@@ -125,11 +125,7 @@ class Publishers {
 
     def unityArtifactoryUpm(String artifactorySecret) {
         jenkins.withEnv(["UNITY_PACKAGE_MANAGER = upm", "UNITY_LOG_CATEGORY=build"]) {
-            jenkins.withCredentials([jenkins.usernamePassword(credentialsId: artifactorySecret, usernameVariable:"UPM_USERNAME", passwordVariable: "UPM_PASSWORD"),
-                                     jenkins.usernameColonPassword(credentialsId: artifactorySecret, variable: "NUGET_KEY"),
-                                     jenkins.usernameColonPassword(credentialsId: artifactorySecret, variable: "nugetkey")]) {
-
-
+            jenkins.withCredentials([jenkins.usernamePassword(credentialsId: artifactorySecret, usernameVariable:"UPM_USERNAME", passwordVariable: "UPM_PASSWORD")]) {
                 gradle.wrapper("publish " +
                         "-Pupm.repository='${releaseType}' " +
                         "-PversionBuilder.stage=${releaseType} " +

--- a/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
+++ b/src/net/wooga/jenkins/pipeline/publish/Publishers.groovy
@@ -105,7 +105,7 @@ class Publishers {
         }
     }
 
-    def unityArtifactoryUpm(String artifactorySecret) {
+    def unityArtifactoryUpmAndPaket(String artifactorySecret) {
         jenkins.withEnv(["UNITY_PACKAGE_MANAGER = upm", "UNITY_LOG_CATEGORY=build"]) {
             jenkins.withCredentials([jenkins.usernamePassword(credentialsId: artifactorySecret, usernameVariable:"UPM_USERNAME", passwordVariable: "UPM_PASSWORD"),
                                      jenkins.usernameColonPassword(credentialsId: artifactorySecret, variable: "NUGET_KEY"),
@@ -122,4 +122,22 @@ class Publishers {
             }
         }
     }
+
+    def unityArtifactoryUpm(String artifactorySecret) {
+        jenkins.withEnv(["UNITY_PACKAGE_MANAGER = upm", "UNITY_LOG_CATEGORY=build"]) {
+            jenkins.withCredentials([jenkins.usernamePassword(credentialsId: artifactorySecret, usernameVariable:"UPM_USERNAME", passwordVariable: "UPM_PASSWORD"),
+                                     jenkins.usernameColonPassword(credentialsId: artifactorySecret, variable: "NUGET_KEY"),
+                                     jenkins.usernameColonPassword(credentialsId: artifactorySecret, variable: "nugetkey")]) {
+
+
+                gradle.wrapper("publish " +
+                        "-Pupm.repository='${releaseType}' " +
+                        "-PversionBuilder.stage=${releaseType} " +
+                        "-PversionBuilder.scope=${releaseScope} "+
+                        "-Prelease.stage=${releaseType} " +
+                        "-Prelease.scope=${releaseScope}")
+            }
+        }
+    }
+
 }

--- a/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
@@ -34,13 +34,16 @@ class WDKConfigSpec extends Specification {
         when:
         def wdkConf = WDKConfig.fromConfigMap(configMap, jenkinsScript)
         then:
-        wdkConf.unityVersions.first().packageType == expected
+        wdkConf.unityVersions.first().packageType == packageType
+        wdkConf.unityVersions.first().autoref == autoref
 
         where:
-        configMap                                                                                       | expected
-        [unityVersions: [[version :"2019", packageType: "paket"]]]                                      | 'paket'
-        [unityVersions: [[version :"2019", packageType: "upm"]]]                                        | 'upm'
-        [unityVersions: [[version :"2019"]]]                                                            | 'any'
+        configMap                                                                                       | packageType  | autoref
+        [unityVersions: [[version :"2019", packageType: "paket"]]]                                      | 'paket'      | true
+        [unityVersions: [[version :"2019", packageType: "upm"]]]                                        | 'upm'        | true
+        [unityVersions: [[version :"2019"]]]                                                            | 'any'        | true
+        [unityVersions: [[version :"2019", autoref: false]]]                                            | 'any'        | false
+        [unityVersions: [[version :"2019", autoref: true]]]                                             | 'any'        | true
     }
 
     @Unroll("creates valid Unity Platform Versions object from #configMap")
@@ -131,7 +134,7 @@ class WDKConfigSpec extends Specification {
         return unityVersionObj.withIndex().collect { Object it, int index ->
             def buildVersion = BuildVersion.parse(it)
             def platform = Platform.forWDK(buildVersion, [:], index == 0)
-            return new WdkUnityBuildVersion(platform, buildVersion, true)
+            return new WdkUnityBuildVersion(platform, buildVersion, "any", true)
         }
     }
 }

--- a/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
@@ -35,15 +35,15 @@ class WDKConfigSpec extends Specification {
         def wdkConf = WDKConfig.fromConfigMap(configMap, jenkinsScript)
         then:
         wdkConf.unityVersions.first().packageType == packageType
-        wdkConf.unityVersions.first().autoref == autoref
+        wdkConf.autoref == autoref
 
         where:
         configMap                                                                                       | packageType  | autoref
         [unityVersions: [[version :"2019", packageType: "paket"]]]                                      | 'paket'      | true
         [unityVersions: [[version :"2019", packageType: "upm"]]]                                        | 'upm'        | true
         [unityVersions: [[version :"2019"]]]                                                            | 'any'        | true
-        [unityVersions: [[version :"2019", autoref: false]]]                                            | 'any'        | false
-        [unityVersions: [[version :"2019", autoref: true]]]                                             | 'any'        | true
+        [unityVersions: [[version :"2019"]], autoref: false]                                            | 'any'        | false
+        [unityVersions: [[version :"2019"]], autoref: true]                                             | 'any'        | true
     }
 
     @Unroll("creates valid Unity Platform Versions object from #configMap")
@@ -126,7 +126,7 @@ class WDKConfigSpec extends Specification {
                 GradleArgs.fromConfigMap([refreshDependencies: refreshDependencies, showStackTrace: showStackTrace, logLevel: logLevel]),
                 DockerArgs.fromConfigMap([:]),
                 CheckArgs.fromConfigMap(jenkinsScript, metadata, [sonarToken: sonarToken]))
-        return new WDKConfig(unityVersions, baseConfig)
+        return new WDKConfig(unityVersions, baseConfig, true)
     }
 
 
@@ -134,7 +134,7 @@ class WDKConfigSpec extends Specification {
         return unityVersionObj.withIndex().collect { Object it, int index ->
             def buildVersion = BuildVersion.parse(it)
             def platform = Platform.forWDK(buildVersion, [:], index == 0)
-            return new WdkUnityBuildVersion(platform, buildVersion, "any", true)
+            return new WdkUnityBuildVersion(platform, buildVersion, "any")
         }
     }
 }

--- a/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/WDKConfigSpec.groovy
@@ -131,7 +131,7 @@ class WDKConfigSpec extends Specification {
         return unityVersionObj.withIndex().collect { Object it, int index ->
             def buildVersion = BuildVersion.parse(it)
             def platform = Platform.forWDK(buildVersion, [:], index == 0)
-            return new WdkUnityBuildVersion(platform, buildVersion, "any")
+            return new WdkUnityBuildVersion(platform, buildVersion, true)
         }
     }
 }

--- a/test/groovy/scripts/BuildUnityWdkV4Spec.groovy
+++ b/test/groovy/scripts/BuildUnityWdkV4Spec.groovy
@@ -24,7 +24,7 @@ class BuildUnityWdkV4Spec extends DeclarativeJenkinsSpec {
 
         when: "running buildWDKAutoSwitch pipeline"
         println packageSetupStash
-        inSandbox { buildWDK(unityVersions: [[version :"2019", autoref: autoref]], clearWs: true) }
+        inSandbox { buildWDK(unityVersions: [[version :"2019"]], clearWs: true, autoref: autoref) }
 
         then: "stashes #stashName setup"
         stash.containsKey(packageSetupStash)

--- a/test/groovy/scripts/BuildUnityWdkV4Spec.groovy
+++ b/test/groovy/scripts/BuildUnityWdkV4Spec.groovy
@@ -35,8 +35,7 @@ class BuildUnityWdkV4Spec extends DeclarativeJenkinsSpec {
         then: "runs gradle with parameters"
         assertShCallsWith(autoref ? 2 : 1, "gradlew",
                 "publish",
-                "-Ppaket.publish.repository='any'",
-                "-Ppublish.repository='any'",
+                "-Pupm.repository='any'",
                 "-PversionBuilder.stage=any",
                 "-PversionBuilder.scope=any"
         ) //2 calls when also building autoref, 1 when not
@@ -70,8 +69,7 @@ class BuildUnityWdkV4Spec extends DeclarativeJenkinsSpec {
         then: "runs gradle with parameters"
         assertShCallsWith(2, "gradlew",
                 "publish",
-                "-Ppaket.publish.repository='${releaseType?:"snapshot"}'",
-                "-Ppublish.repository='${releaseType?:"snapshot"}'",
+                "-Pupm.repository='${releaseType?:"snapshot"}'",
                 "-PversionBuilder.stage=${releaseType?:"snapshot"}",
                 "${releaseScope? "-PversionBuilder.scope=${releaseScope}": ''}"
         ) //2 calls 1 for autoref, 1 for default

--- a/test/groovy/scripts/BuildUnityWdkV4Spec.groovy
+++ b/test/groovy/scripts/BuildUnityWdkV4Spec.groovy
@@ -1,0 +1,247 @@
+package scripts
+
+
+import spock.lang.Unroll
+import tools.DeclarativeJenkinsSpec
+
+class BuildUnityWdkV4Spec extends DeclarativeJenkinsSpec {
+    private static final String SCRIPT_PATH = "vars/buildUnityWdkV4.groovy"
+
+    @Unroll("publishes Default or Autoref WDK depending on versions #autoref")
+    def "publishes Default or Autoref WDK depending on versions #packageType"() {
+        given: "credentials holder with publish keys"
+        credentials.addUsernamePassword("artifactory_publish", "artifactory_publish_usr", "artifactory_publish_pwd")
+        credentials.addUsernamePassword("artifactory_deploy", "artifactory_deploy_usr", "artifactory_deploy_pwd")
+        credentials.addUsernamePassword('github_access', "github_access_usr", "github_access_pwd")
+        and: "build plugin with publish parameters"
+        def buildWDK = loadSandboxedScript(SCRIPT_PATH) {
+            params.RELEASE_STAGE = "any"
+            params.RELEASE_SCOPE = "any"
+            env.GRGIT_USR = "usr"
+            env.GRGIT_PSW = "pwd"
+        }
+        def packageSetupStash = "${stashName}_setup_w" as String
+
+        when: "running buildWDKAutoSwitch pipeline"
+        println packageSetupStash
+        inSandbox { buildWDK(unityVersions: [[version :"2019", autoref: autoref]], clearWs: true) }
+
+        then: "stashes #stashName setup"
+        stash.containsKey(packageSetupStash)
+        and: "don't stashes other paket setup"
+        def numberOfSetupStashes = stash.findAll { it.key.endsWith("_setup_w") }.size()
+        numberOfSetupStashes == autoref ? 2 : 1
+
+        then: "runs gradle with parameters"
+        assertShCallsWith(autoref ? 2 : 1, "gradlew",
+                "publish",
+                "-Ppaket.publish.repository='any'",
+                "-Ppublish.repository='any'",
+                "-PversionBuilder.stage=any",
+                "-PversionBuilder.scope=any"
+        ) //2 calls when also building autoref, 1 when not
+
+        cleanup:
+        stash.clear()
+
+        where:
+        autoref   | stashName
+        true      | "autoref"
+        false     | "default"
+    }
+
+    @Unroll("publishes Default/Autoref WDK #releaseType-#releaseScope release")
+    def "publishes Default/Autoref WDK with #release release type"() {
+        given: "credentials holder with publish keys"
+        credentials.addUsernamePassword("artifactory_publish", "artifactory_publish_usr", "artifactory_publish_pwd")
+        credentials.addUsernamePassword("artifactory_deploy", "artifactory_deploy_usr", "artifactory_deploy_pwd")
+        credentials.addUsernamePassword('github_access', "github_access_usr", "github_access_pwd")
+        and: "build plugin with publish parameters"
+        def buildWDK = loadSandboxedScript(SCRIPT_PATH) {
+            params.RELEASE_STAGE = releaseType
+            params.RELEASE_SCOPE = releaseScope
+            env.GRGIT_USR = "usr"
+            env.GRGIT_PSW = "pwd"
+        }
+
+        when: "running buildWDKAutoSwitch pipeline"
+        inSandbox { buildWDK(unityVersions: ["2019"], logLevel: "level") }
+
+        then: "runs gradle with parameters"
+        assertShCallsWith(2, "gradlew",
+                "publish",
+                "-Ppaket.publish.repository='${releaseType?:"snapshot"}'",
+                "-Ppublish.repository='${releaseType?:"snapshot"}'",
+                "-PversionBuilder.stage=${releaseType?:"snapshot"}",
+                "${releaseScope? "-PversionBuilder.scope=${releaseScope}": ''}"
+        ) //2 calls 1 for autoref, 1 for default
+        and: "has set up environment"
+        for (int i = 1 ; i <= 2; i++) {
+            def env = usedEnvironments[usedEnvironments.size() - i]
+            hasBaseEnvironment(env, "level")
+            env.GRGIT == this.credentials['github_access']
+            env.GRGIT_USER == "usr" //"${GRGIT_USR}"
+            env.GRGIT_PASS == "pwd" //"${GRGIT_PSW}"
+            env.GITHUB_LOGIN == "usr" //"${GRGIT_USR}"
+            env.GITHUB_PASSWORD == "pwd" //"${GRGIT_PSW}"
+            env.UNITY_PACKAGE_MANAGER == "upm"
+            env.UNITY_LOG_CATEGORY == "build"
+            env.UPM_USERNAME == artifactory_user //artifactory_publish user
+            env.UPM_PASSWORD == artifactory_password //artifactory_publish password
+            env.NUGET_KEY == this.credentials[artifactory_credentials]
+            env.WDK_SETUP_AUTOREF == (i == 1) ? "true" : "false"
+        }
+
+        where:
+        releaseType | releaseScope
+        null        | null
+        "snapshot"  | "patch"
+        "preflight" | "minor"
+        "rc"        | "minor"
+        "final"     | "major"
+
+        github_user = "github_access_usr"
+        github_password = "github_access_pwd"
+        artifactory_deploy_user = "artifactory_deploy_usr"
+        artifactory_deploy_password = "artifactory_deploy_pwd"
+        artifactory_publish_user = "artifactory_publish_usr"
+        artifactory_publish_password = "artifactory_publish_pwd"
+
+        artifactory_user = releaseType == "snapshot" || releaseType == null ? artifactory_publish_user : artifactory_deploy_user
+        artifactory_password = releaseType == "snapshot" || releaseType == null ? artifactory_publish_password : artifactory_deploy_password
+
+        artifactory_credentials = releaseType == "snapshot" || releaseType == null ? "artifactory_publish" : "artifactory_deploy"
+    }
+
+
+    @Unroll("assemblies WDK for #releaseType-#releaseScope release ")
+    def "assemblies UPM WDK with given release data"() {
+        given: "needed credentials"
+        def upmCredsFile = credentials.addFile("atlas-upm-credentials", "creds")
+        credentials.addUsernamePassword("artifactory_read", "key", "pwd")
+        and: "build plugin with publish parameters"
+        def buildWDK = loadSandboxedScript(SCRIPT_PATH) {
+            params.RELEASE_STAGE = releaseType
+            params.RELEASE_SCOPE = releaseScope
+        }
+
+        when: "running buildWDKAutoSwitch pipeline"
+        inSandbox { buildWDK(unityVersions: ["2018"], logLevel: "level") }
+        then: "runs gradle with parameters"
+        assertShCallsWith("gradlew",
+                "-Prelease.stage=${releaseType}",
+                "-Prelease.scope=${releaseScope}",
+                "assemble")
+
+        and: "has set up environment"
+        def env = usedEnvironments.last()
+        hasBaseEnvironment(env, "level")
+        env.UNITY_LOG_CATEGORY == "build"
+        env.UPM_USER_CONFIG_FILE == upmCredsFile.absolutePath
+
+        and: "stashes gradle cache and build outputs"
+        stash['wdk_output']["includes"] == ".gradle/**, **/build/outputs/**/*"
+
+        where:
+        releaseType | releaseScope
+        "snapshot"  | "patch"
+        "preflight" | "minor"
+        "rc"        | "minor"
+        "final"     | "major"
+    }
+
+    @Unroll("sets up WDK (Default and Autoreferenced) for #releaseType-#releaseScope release")
+    def "sets up WDK (Default and Autoreferenced) with given release data"() {
+        given: "needed credentials"
+        credentials.addUsernamePassword("artifactory_read", "key", "pwd")
+        and: "build plugin with publish parameters"
+        def buildWDK = loadSandboxedScript(SCRIPT_PATH) {
+            params.RELEASE_STAGE = releaseType
+            params.RELEASE_SCOPE = releaseScope
+        }
+
+        when: "running buildWDKAutoSwitch pipeline"
+        inSandbox {
+            buildWDK(unityVersions: ["2018"], logLevel: "level", forceRefreshDependencies: forceRefreshDependencies)
+        }
+
+        then: "runs gradle with parameters"
+        assertShCallsWith(2, "gradlew", //2 calls 1 for autoref, 1 for default
+                "-Prelease.stage=${releaseType}",
+                "-Prelease.scope=${releaseScope}",
+                "setup")
+
+        and: "stashes upm setup"
+        stash['default_setup_w'].with {
+            assert useDefaultExcludes == true
+            assert includes == ".gradle/**, **/build/**, Packages/**, **/PackageCache/**"
+        }
+        and: "stashes paket setup"
+        stash['autoref_setup_w'].with {
+            useDefaultExcludes == true
+            includes == ".gradle/**, **/build/**, Packages/**, **/PackageCache/**"
+        }
+
+        and: "sets up environment"
+        def env = usedEnvironments[0]   // this is the setup autoref environment
+        env.WDK_SETUP_AUTOREF == "true"
+        def env2 = usedEnvironments[1]  // this is the setup default environment
+        env2.WDK_SETUP_AUTOREF == "false"
+
+        where:
+        releaseType | releaseScope | forceRefreshDependencies
+        "snapshot"  | "patch"      | false
+        "preflight" | "patch"      | false
+        "rc"        | "minor"      | false
+        "final"     | "major"      | false
+        "snapshot"  | "patch"      | true
+        "preflight" | "patch"      | true
+        "rc"        | "minor"      | true
+        "final"     | "major"      | true
+    }
+
+    @Unroll("#description workspace steps when clearWs is #clearWs")
+    def "clears steps if clearWs is set"() {
+        given: "loaded check in a running jenkins build"
+        def buildWDK = loadSandboxedScript(SCRIPT_PATH) {
+            params.RELEASE_STAGE = "any"
+            params.RELEASE_SCOPE = "any"
+        }
+
+        when: "running pipeline"
+        inSandbox {
+            buildWDK(unityVersions: ["2019"], clearWs: clearWs)
+        }
+
+        then: "all workspaces are clean"
+        calls["cleanWs"].length == (clearWs ? 5 : 0) //setup x2, build, and publish x2 steps
+
+        where:
+        clearWs << [true, false]
+        description = clearWs ? "clears" : "doesn't clear"
+    }
+
+    def hasBaseEnvironment(Map env, String logLevel) {
+        env.with {
+            UVM_AUTO_SWITCH_UNITY_EDITOR == "YES" &&
+                    UVM_AUTO_INSTALL_UNITY_EDITOR == "YES" &&
+                    LOG_LEVEL == logLevel &&
+                    ATLAS_READ == this.credentials["artifactory_read"]
+        }
+    }
+
+    def assertShCallsWith(int count = 1, String... elements) {
+        def callArgs = calls["sh"].collect { it.args[0]["script"] as String }
+        def found = callArgs.findAll { args ->
+            elements.every { args.contains(it) }
+        }
+        assert found.size() == count,
+                "${found.size()} sh call with arguments [${elements.join(", ")}] found in:\n [${pprintList(callArgs)}]"
+        return found
+    }
+
+    def pprintList(List<?> list) {
+        return list.collect { it.toString() }.join("\n")
+    }
+
+}

--- a/vars/buildUnityWdkV2.groovy
+++ b/vars/buildUnityWdkV2.groovy
@@ -245,7 +245,7 @@ def call(Map configMap = [unityVersions: []]) {
             // This is a hack until we implement a better solution (ex: remove the paket.template files when doing paketUnityInstall)
             sh script: "find Packages -type f -iname \"paket.template\" | xargs rm"
             def publisher = config.pipelineTools.createPublishers(env.RELEASE_STAGE, env.RELEASE_SCOPE)
-            publisher.unityArtifactoryUpm(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish": "artifactory_deploy")
+            publisher.unityArtifactoryUpmAndPaket(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish": "artifactory_deploy")
           }
         }
 

--- a/vars/buildUnityWdkV3.groovy
+++ b/vars/buildUnityWdkV3.groovy
@@ -275,7 +275,7 @@ def call(Map configMap = [unityVersions: []]) {
             // This is a hack until we implement a better solution (ex: remove the paket.template files when doing paketUnityInstall)
             sh script: "find Packages -type f -iname \"paket.template\" | xargs rm"
             def publisher = config.pipelineTools.createPublishers(env.RELEASE_STAGE, env.RELEASE_SCOPE)
-            publisher.unityArtifactoryUpm(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish": "artifactory_deploy")
+            publisher.unityArtifactoryUpmAndPaket(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish": "artifactory_deploy")
           }
         }
 

--- a/vars/buildUnityWdkV4.groovy
+++ b/vars/buildUnityWdkV4.groovy
@@ -165,8 +165,6 @@ def call(Map configMap = [unityVersions: []]) {
             post {
               always {
                 stash(name: 'wdk_output', includes: ".gradle/**, **/build/outputs/**/*")
-                archiveArtifacts artifacts: '**/build/distributions/*.tgz', allowEmptyArchive: true
-                archiveArtifacts artifacts: 'build/outputs/*.unitypackage', allowEmptyArchive: true
                 archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
               }
               cleanup {
@@ -223,6 +221,7 @@ def call(Map configMap = [unityVersions: []]) {
 
             post {
               always {
+                archiveArtifacts artifacts: '**/build/distributions/*.tgz', allowEmptyArchive: true
                 archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
               }
               cleanup {
@@ -258,6 +257,7 @@ def call(Map configMap = [unityVersions: []]) {
 
             post {
               always {
+                archiveArtifacts artifacts: '**/build/distributions/*.tgz', allowEmptyArchive: true
                 archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
               }
               cleanup {

--- a/vars/buildUnityWdkV4.groovy
+++ b/vars/buildUnityWdkV4.groovy
@@ -271,10 +271,10 @@ def call(Map configMap = [unityVersions: []]) {
           }
         }
       }
-      post {
-        always {
-          sendSlackNotification currentBuild.result, true
-        }
+    }
+    post {
+      always {
+        sendSlackNotification currentBuild.result, true
       }
     }
   }

--- a/vars/buildUnityWdkV4.groovy
+++ b/vars/buildUnityWdkV4.groovy
@@ -72,7 +72,7 @@ def call(Map configMap = [unityVersions: []]) {
               GRGIT_PASS = "${GRGIT_PSW}"
               GITHUB_LOGIN = "${GRGIT_USR}"
               GITHUB_PASSWORD = "${GRGIT_PSW}"
-              SETUP_UNITY_AUTOREF = "true"
+              WDK_SETUP_AUTOREF = "true"
             }
             steps {
               script {
@@ -112,7 +112,7 @@ def call(Map configMap = [unityVersions: []]) {
               GRGIT_PASS = "${GRGIT_PSW}"
               GITHUB_LOGIN = "${GRGIT_USR}"
               GITHUB_PASSWORD = "${GRGIT_PSW}"
-              SETUP_UNITY_AUTOREF = "false"
+              WDK_SETUP_AUTOREF = "false"
             }
             steps {
               script {

--- a/vars/buildUnityWdkV4.groovy
+++ b/vars/buildUnityWdkV4.groovy
@@ -24,7 +24,7 @@ def call(Map configMap = [unityVersions: []]) {
     }
   }
   def config = WDKConfig.fromConfigMap(configMap, this)
-  def hasToPublishAutoref = config.unityVersions.any({ version -> version.autoref == "any" || version.autoref == "true" })
+  def hasToPublishAutoref = config.unityVersions.any({ version -> version.autoref })
 
   // We can only configure static pipelines atm.
   // To test multiple unity versions we use a script block with a parallel stages inside.
@@ -237,7 +237,11 @@ def call(Map configMap = [unityVersions: []]) {
             agent {
               label "atlas && macos"
             }
-
+            when {
+              expression {
+                hasToPublishAutoref
+              }
+            }
             environment {
               GRGIT = credentials('github_access')
               UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')

--- a/vars/buildUnityWdkV4.groovy
+++ b/vars/buildUnityWdkV4.groovy
@@ -1,0 +1,330 @@
+#!/usr/bin/env groovy
+import net.wooga.jenkins.pipeline.check.steps.Step
+import net.wooga.jenkins.pipeline.config.PipelineConventions
+import net.wooga.jenkins.pipeline.config.Platform
+import net.wooga.jenkins.pipeline.config.WDKConfig
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                                                    //
+// Step buildUnityWdkV4                                                                                               //
+//                                                                                                                    //
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+def call(Map configMap = [unityVersions: []]) {
+  def defaultReleaseType = "snapshot"
+  def defaultReleaseScope = ""
+
+  configMap.logLevel = configMap.get("logLevel", params.LOG_LEVEL ?: env.LOG_LEVEL as String)
+  configMap.showStackTrace = configMap.get("showStackTrace", params.STACK_TRACE as Boolean)
+  configMap.refreshDependencies = configMap.get("refreshDependencies", params.REFRESH_DEPENDENCIES as Boolean)
+  configMap.clearWs = configMap.get("clearWs", params.CLEAR_WS as boolean)
+  configMap.testWrapper = { Step testOperation, Platform plat ->
+    withCredentials([file(credentialsId: 'atlas-upm-credentials', variable: "UPM_USER_CONFIG_FILE")]) {
+      testOperation(plat)
+    }
+  }
+  def config = WDKConfig.fromConfigMap(configMap, this)
+  def hasToPublishAutoref = config.unityVersions.any({ version -> version.autoref == "any" || version.autoref == "true" })
+
+  // We can only configure static pipelines atm.
+  // To test multiple unity versions we use a script block with a parallel stages inside.
+  pipeline {
+    agent none
+
+    options {
+      buildDiscarder(logRotator(artifactNumToKeepStr: '40'))
+    }
+
+    environment {
+      UVM_AUTO_SWITCH_UNITY_EDITOR = "YES"
+      UVM_AUTO_INSTALL_UNITY_EDITOR = "YES"
+      LOG_LEVEL = "${config.gradleArgs.logLevel}"
+      ATLAS_READ = credentials('artifactory_read') //needed for gradle sto read private packages
+    }
+
+    parameters {
+      choice(name: 'RELEASE_STAGE', choices: [defaultReleaseType, "preflight", "rc", "final"], description: 'Choose the distribution type')
+      choice(name: 'RELEASE_SCOPE', choices: [defaultReleaseScope, "patch", "minor", "major"], description: 'Choose the scope (semver2)')
+      choice(name: 'LOG_LEVEL', choices: ["info", "quiet", "warn", "debug"], description: 'Choose the log level')
+      choice(name: 'UPM_RESOLUTION_STRATEGY', choices: ["", "lowest", "highestPatch", "highestMinor", "highest"], description: 'Override the resolution strategy for indirect dependencies')
+      booleanParam(name: 'STACK_TRACE', defaultValue: false, description: 'Whether to log truncated stacktraces')
+      booleanParam(name: 'REFRESH_DEPENDENCIES', defaultValue: false, description: 'Whether to refresh dependencies')
+      booleanParam(name: 'CLEAR_WS', defaultValue: false, description: 'Whether to clear workspaces after build')
+    }
+
+    stages {
+      stage("Setup") {
+        failFast true
+        parallel {
+          stage("setup autoref") {
+            when {
+              expression {
+                hasToPublishAutoref
+              }
+            }
+            agent {
+              label "atlas && macos"
+            }
+            environment {
+              UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
+              GRGIT = credentials('github_access')
+              GRGIT_USER = "${GRGIT_USR}"
+              GRGIT_PASS = "${GRGIT_PSW}"
+              GITHUB_LOGIN = "${GRGIT_USR}"
+              GITHUB_PASSWORD = "${GRGIT_PSW}"
+              SETUP_UNITY_AUTOREF = "true"
+            }
+            steps {
+              script {
+                env.RELEASE_STAGE = params.RELEASE_STAGE ?: defaultReleaseType
+                env.RELEASE_SCOPE = params.RELEASE_SCOPE ?: defaultReleaseScope
+                def setup = config.pipelineTools.setups
+                setup.wdk(env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
+              }
+            }
+            post {
+              success {
+                stash(name: 'autoref_setup_w', useDefaultExcludes: true, includes: ".gradle/**, **/build/**, Packages/**, **/PackageCache/**")
+              }
+
+              always {
+                archiveArtifacts artifacts: '**/Packages/**/package.json, **/Packages/manifest.json, **/Packages/packages-lock.json, **/build/logs/*.log', allowEmptyArchive: true
+              }
+
+              cleanup {
+                script {
+                  if (config.mainPlatform.clearWs) {
+                    cleanWs()
+                  }
+                }
+              }
+            }
+          }
+
+          stage("setup default") {
+            agent {
+              label "atlas && macos"
+            }
+            environment {
+              GRGIT = credentials('github_access')
+              UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
+              GRGIT_USER = "${GRGIT_USR}"
+              GRGIT_PASS = "${GRGIT_PSW}"
+              GITHUB_LOGIN = "${GRGIT_USR}"
+              GITHUB_PASSWORD = "${GRGIT_PSW}"
+              SETUP_UNITY_AUTOREF = "false"
+            }
+            steps {
+              script {
+                env.RELEASE_STAGE = params.RELEASE_STAGE ?: defaultReleaseType
+                env.RELEASE_SCOPE = params.RELEASE_SCOPE ?: defaultReleaseScope
+                def setup = config.pipelineTools.setups
+                setup.wdk(env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
+              }
+            }
+            post {
+              success {
+                archiveArtifacts artifacts: '**/Packages/packages-lock.json'
+                stash(name: 'default_setup_w', useDefaultExcludes: true, includes: ".gradle/**, **/build/**, Packages/**, **/PackageCache/**")
+
+              }
+
+              always {
+                archiveArtifacts artifacts: '**/Packages/**/package.json, **/Packages/manifest.json, **/Packages/packages-lock.json, **/build/logs/*.log', allowEmptyArchive: true
+              }
+              cleanup {
+                script {
+                  if (config.mainPlatform.clearWs) {
+                    cleanWs()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      stage("Build") {
+        failFast true
+        parallel {
+          stage('assemble default') {
+            agent {
+              label "atlas && macos"
+            }
+            environment {
+              UNITY_PACKAGE_MANAGER = 'upm'
+              UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
+            }
+            steps {
+              unstash 'default_setup_w'
+              script {
+                def assembler = config.pipelineTools.assemblers
+                assembler.unityWDK("build", env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
+              }
+            }
+
+            post {
+              always {
+                stash(name: 'wdk_output', includes: ".gradle/**, **/build/outputs/**/*")
+                archiveArtifacts artifacts: '**/build/distributions/*.tgz', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'build/outputs/*.unitypackage', allowEmptyArchive: true
+                archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
+              }
+              cleanup {
+                script {
+                  if (config.mainPlatform.clearWs) {
+                    cleanWs()
+                  }
+                }
+              }
+            }
+          }
+
+          stage('assemble autoref') {
+            when {
+              expression {
+                hasToPublishAutoref
+              }
+            }
+            agent {
+              label "atlas && macos"
+            }
+            environment {
+              UNITY_PACKAGE_MANAGER = 'upm'
+              UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
+            }
+            steps {
+              unstash 'autoref_setup_w'
+              script {
+                def assembler = config.pipelineTools.assemblers
+                assembler.unityWDK("build", env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
+              }
+            }
+
+            post {
+              always {
+                archiveArtifacts artifacts: '**/build/distributions/*.tgz', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'build/outputs/*.unitypackage', allowEmptyArchive: true
+                archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
+              }
+              cleanup {
+                script {
+                  if (config.mainPlatform.clearWs) {
+                    cleanWs()
+                  }
+                }
+              }
+            }
+          }
+
+          stage("Check") {
+            failFast true
+            when {
+              beforeAgent true
+              expression {
+                return env.RELEASE_STAGE == "snapshot"
+              }
+            }
+            steps {
+              script {
+                parallel checkSteps(config, "check unity ", "default_setup_w")
+              }
+            }
+          }
+        }
+      }
+
+      stage("Publish") {
+        failFast true
+        parallel {
+          stage('Default') {
+            agent {
+              label "atlas && macos"
+            }
+
+            environment {
+              GRGIT = credentials('github_access')
+              UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
+              GRGIT_USER = "${GRGIT_USR}"
+              GRGIT_PASS = "${GRGIT_PSW}"
+              GITHUB_LOGIN = "${GRGIT_USR}"
+              GITHUB_PASSWORD = "${GRGIT_PSW}"
+            }
+
+            steps {
+              script {
+                unstash 'default_setup_w'
+                def publisher = config.pipelineTools.createPublishers(env.RELEASE_STAGE, env.RELEASE_SCOPE)
+                publisher.unityArtifactoryUpm(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish" : "artifactory_deploy")
+              }
+            }
+
+            post {
+              always {
+                archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
+              }
+              cleanup {
+                script {
+                  if (config.mainPlatform.clearWs) {
+                    cleanWs()
+                  }
+                }
+              }
+            }
+          }
+          stage('Autoref') {
+            agent {
+              label "atlas && macos"
+            }
+
+            environment {
+              GRGIT = credentials('github_access')
+              UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
+              GRGIT_USER = "${GRGIT_USR}"
+              GRGIT_PASS = "${GRGIT_PSW}"
+              GITHUB_LOGIN = "${GRGIT_USR}"
+              GITHUB_PASSWORD = "${GRGIT_PSW}"
+            }
+
+            steps {
+              script {
+                unstash 'autoref_setup_w'
+                def publisher = config.pipelineTools.createPublishers(env.RELEASE_STAGE, env.RELEASE_SCOPE)
+                publisher.unityArtifactoryUpm(env.RELEASE_STAGE == defaultReleaseType ? "artifactory_publish" : "artifactory_deploy")
+              }
+            }
+
+            post {
+              always {
+                archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
+              }
+              cleanup {
+                script {
+                  if (config.mainPlatform.clearWs) {
+                    cleanWs()
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      post {
+        always {
+          sendSlackNotification currentBuild.result, true
+        }
+      }
+    }
+  }
+}
+
+def checkSteps(WDKConfig config, String parallelChecksPrefix, String setupStashId) {
+  def conventions = new PipelineConventions(config.conventions)
+  conventions.wdkParallelPrefix = parallelChecksPrefix
+  conventions.wdkSetupStashId = setupStashId
+  def checks = config.pipelineTools.checks.forWDKPipelines()
+  def stepsForParallel = checks.wdkCoverage(config.unityVersions,
+      env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String,
+      config.checkArgs, conventions)
+  return stepsForParallel
+}

--- a/vars/buildUnityWdkV4.groovy
+++ b/vars/buildUnityWdkV4.groovy
@@ -24,7 +24,6 @@ def call(Map configMap = [unityVersions: []]) {
     }
   }
   def config = WDKConfig.fromConfigMap(configMap, this)
-  def hasToPublishAutoref = config.unityVersions.any({ version -> version.autoref })
 
   // We can only configure static pipelines atm.
   // To test multiple unity versions we use a script block with a parallel stages inside.
@@ -59,7 +58,7 @@ def call(Map configMap = [unityVersions: []]) {
           stage("setup autoref") {
             when {
               expression {
-                hasToPublishAutoref
+                config.autoref
               }
             }
             agent {
@@ -239,7 +238,7 @@ def call(Map configMap = [unityVersions: []]) {
             }
             when {
               expression {
-                hasToPublishAutoref
+                config.autoref
               }
             }
             environment {

--- a/vars/buildUnityWdkV4.groovy
+++ b/vars/buildUnityWdkV4.groovy
@@ -147,12 +147,11 @@ def call(Map configMap = [unityVersions: []]) {
       stage("Build") {
         failFast true
         parallel {
-          stage('assemble default') {
+          stage('Assemble') {
             agent {
               label "atlas && macos"
             }
             environment {
-              UNITY_PACKAGE_MANAGER = 'upm'
               UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
             }
             steps {
@@ -166,43 +165,6 @@ def call(Map configMap = [unityVersions: []]) {
             post {
               always {
                 stash(name: 'wdk_output', includes: ".gradle/**, **/build/outputs/**/*")
-                archiveArtifacts artifacts: '**/build/distributions/*.tgz', allowEmptyArchive: true
-                archiveArtifacts artifacts: 'build/outputs/*.unitypackage', allowEmptyArchive: true
-                archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true
-              }
-              cleanup {
-                script {
-                  if (config.mainPlatform.clearWs) {
-                    cleanWs()
-                  }
-                }
-              }
-            }
-          }
-
-          stage('assemble autoref') {
-            when {
-              expression {
-                hasToPublishAutoref
-              }
-            }
-            agent {
-              label "atlas && macos"
-            }
-            environment {
-              UNITY_PACKAGE_MANAGER = 'upm'
-              UPM_USER_CONFIG_FILE = credentials('atlas-upm-credentials')
-            }
-            steps {
-              unstash 'autoref_setup_w'
-              script {
-                def assembler = config.pipelineTools.assemblers
-                assembler.unityWDK("build", env.RELEASE_STAGE as String, env.RELEASE_SCOPE as String)
-              }
-            }
-
-            post {
-              always {
                 archiveArtifacts artifacts: '**/build/distributions/*.tgz', allowEmptyArchive: true
                 archiveArtifacts artifacts: 'build/outputs/*.unitypackage', allowEmptyArchive: true
                 archiveArtifacts artifacts: '**/build/logs/*.log', allowEmptyArchive: true

--- a/vars/buildUnityWdkV4.txt
+++ b/vars/buildUnityWdkV4.txt
@@ -1,0 +1,28 @@
+Custom step to build, test and deploy Wooga's Unity projects.
+
+Arguments:
+
+- unityVersions: []
+    - $VERSION: ""
+    - $OPTIONAL: [true, false]
+    - $AUTOREF: ["any", "true", "false"]
+    - $API_COMPAT_LEVEL: [net4_6, net2_0_subset]
+    - $LABEL: [macos, linux]
+- refreshDependencies: [true, false]
+- logLevel: [quiet, warning, info, debug]
+- testLabels: []
+- labels: []
+
+Usage:
+
+"def args = 
+[
+    refreshDependencies : true,
+    unityVersions : 
+    [
+        '$VERSION1', 
+        '$VERSION2', 
+        [version : '$VERSION3', optional : $BOOLEAN, autoref : $AUTOREF, apiCompatibilityLevel: '$API_COMPAT_LEVEL', label: '$PLATFORM']
+    ],
+]
+buildUnityWdkV4 args"


### PR DESCRIPTION
## Description

Adds new buildUnityWdkV4 Pipeline. This pipeline requires WDKs to be on `wdk-unity >= 6.0.0` plugin. 

* removes all paket-related setup.
* adds a new parallel setup step to convert the WDK into autoreferenced mode. This also will test if the conversion worked in the setup call's resolvePackages task by the new version of wdk-unity.
* adds a new parallel publish step to publish that autoreferenced version of the WDK

## Changes
* ![NEW] add new buildUnityWdkV4
* ![ADD] add new functionality to publish autoreferenced WDKs

[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"

