### PR TITLE
Always tar on cache update

### DIFF
--- a/src/net/wooga/jenkins/pipeline/cache/Cache.groovy
+++ b/src/net/wooga/jenkins/pipeline/cache/Cache.groovy
@@ -36,10 +36,10 @@ class Cache {
         def pathInCache = "$cacheLocation/$relativePathFolderToBeCached"
         if(!jenkins.fileExists(pathInCache)) {
             jenkins.sh "umask 002 && mkdir -p $pathInCache || true"
-            return tarCopy(jenkins, ".", "$relativePathFolderToBeCached/", cacheLocation)
         } else {
-            return rsync(jenkins, "$relativePathFolderToBeCached/", "$cacheLocation/$relativePathFolderToBeCached")
+            jenkins.sh "rm -rf $pathInCache/* || true"
         }
+        return tarCopy(jenkins, ".", "$relativePathFolderToBeCached/", cacheLocation)
     }
 
     def hasFiles(List<String> files) {


### PR DESCRIPTION
## Description


## Changes
* ![IMPROVE] Always delete cache and tar in new cache instead of rsync on cache update




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
