### PR TITLE
More robust way of reading for last modified date from file in cache

### DIFF
--- a/test/groovy/net/wooga/jenkins/pipeline/cache/CacheSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/cache/CacheSpec.groovy
@@ -88,7 +88,7 @@ class CacheSpec extends Specification {
         }
 
         then:
-        cache.lastModified.ageMs < 1000 // Ensure the cache was updated
+        cache.lastModified.ageMs > 0 && cache.lastModified.ageMs < 1000 // Ensure the cache was updated
         assert Files.walk(cacheRoot.toPath()).anyMatch {
             it.toString().endsWith("/project/$jenkins.BRANCH_NAME/testFolder/Subfolder/file1.txt")
         }


### PR DESCRIPTION
## Description
For some stupid reason, `echo -n '12345'` is printing "-n '12345'" to file, instead of just '12345' without the line break. This PR changes the writing command to just `echo '12345'` and modifies the `getLastModifiedMs()` function to return the first digit in the file, instead of expecting the whole content of the file to be a number. 

## Changes
* ![FIX] cache not reading last modified date as it should




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
