### PR TITLE
More robust cache failures

### DIFF
--- a/test/groovy/net/wooga/jenkins/pipeline/cache/CacheSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/cache/CacheSpec.groovy
@@ -8,6 +8,10 @@ import java.nio.file.Paths
 class FakeJenkins {
     def BRANCH_NAME = "branch"
     def env = [BRANCH_NAME: BRANCH_NAME]
+    List<String> failMatchingSh = []
+    final List<Map<String, Object>> shInvocations = []
+    def failShStatus = 1
+
     def workspaceRoot = new File("build/tests/workspace").with {
         it.deleteDir()
         it.mkdirs()
@@ -46,6 +50,15 @@ class FakeJenkins {
     }
 
     def sh(Map<String, Object> args) {
+        shInvocations.add(args)
+        if (failMatchingSh.any { args.script.toString().matches(it) }) {
+            return fakeSh(args, failShStatus)
+        } else {
+            return realSh(args)
+        }
+    }
+
+    protected def realSh(Map<String, Object> args) {
         String script = args.script
         def returnStatus = args.getOrDefault("returnStatus", false)
         println "Executing script: $script"
@@ -63,11 +76,20 @@ class FakeJenkins {
             throw new RuntimeException("Script failed with status $status: $script")
         }
     }
+
+    protected def fakeSh(Map<String, Object> args, int fakeStatus) {
+        def returnStatus = args.getOrDefault("returnStatus", false)
+        if (returnStatus) {
+            return fakeStatus // Simulate success
+        } else if(fakeStatus != 0) {
+            throw new RuntimeException("Script failed with status $fakeStatus: $args.script")
+        }
+    }
 }
 
 class CacheSpec extends Specification {
 
-    def "renewProjectCache with valid parameters"() {
+    def "renews project cache with valid parameters"() {
         given: "a Cache instance with mock Jenkins"
         def cacheRoot = Files.createTempDirectory("cacheRoot").toFile()
         def jenkins = new FakeJenkins()
@@ -82,12 +104,13 @@ class CacheSpec extends Specification {
         def cache = new Cache(jenkins, cacheRoot.absolutePath, "project", true)
 
         when: "renewProjectCache is called with a closure that generates assets"
-        cache.renewProjectCache("testFolder", 1000) {
+        def success = cache.renewProjectCache("testFolder", 1000) {
             jenkins.echo("Generating assets")
             Thread.sleep(500)
         }
 
         then:
+        success
         cache.lastModified.ageMs > 0 && cache.lastModified.ageMs < 1000 // Ensure the cache was updated
         assert Files.walk(cacheRoot.toPath()).anyMatch {
             it.toString().endsWith("/project/$jenkins.BRANCH_NAME/testFolder/Subfolder/file1.txt")
@@ -98,6 +121,82 @@ class CacheSpec extends Specification {
         assert Files.walk(cacheRoot.toPath()).anyMatch {
             it.toString().endsWith("/project/$jenkins.BRANCH_NAME/testFolder/file3.asset")
         }
+        cleanup:
+        jenkins.workspaceRoot.deleteDir()
+        cacheRoot.deleteDir()
+    }
+
+    def "deletes cache content if cache renewal failed"() {
+        given: "a Cache instance with mock Jenkins"
+        def cacheRoot = Files.createTempDirectory("cacheRoot").toFile()
+        def jenkins = new FakeJenkins()
+        jenkins.failMatchingSh = [
+                "^.*gtar\\s.+\$",
+                "^.*rsync\\s.+\$"
+        ]
+        jenkins.workspaceRoot.with {
+            new File(it, "testFolder/Subfolder/file1.txt").with {
+                it.parentFile.mkdirs()
+                it.createNewFile()
+            }
+            new File(it, "testFolder/file2.asset").createNewFile()
+            new File(it, "testFolder/file3.asset").createNewFile()
+        }
+        def cache = new Cache(jenkins, cacheRoot.absolutePath, "project", true)
+
+        when: "renewProjectCache is called with a closure that generates assets"
+        def success = cache.renewProjectCache("testFolder", 1000) {
+            jenkins.echo("Generating assets")
+        }
+
+        then:
+        !success
+        jenkins.shInvocations.size() > 0
+        jenkins.shInvocations.any {
+            it.script.toString().contains("rm -rf '${cacheRoot.absolutePath}/project/branch/testFolder'")
+        }
+        cleanup:
+        jenkins.workspaceRoot.deleteDir()
+        cacheRoot.deleteDir()
+    }
+
+    def "deletes local content and retries if cache fetch fails"() {
+        given: "a Cache instance with mock Jenkins"
+        def cacheRoot = Files.createTempDirectory("cacheRoot").toFile()
+        def projectCache = new File(cacheRoot, "project/branch")
+        def jenkins = new FakeJenkins()
+        jenkins.failMatchingSh = [
+                "^.*gtar\\s.+\$",
+                "^.*rsync\\s.+\$"
+        ]
+        projectCache.with {
+            new File(projectCache, "testFolder/Subfolder/file1.txt").with {
+                it.parentFile.mkdirs()
+                it.createNewFile()
+            }
+            new File(projectCache, "testFolder/file2.asset").createNewFile()
+            new File(projectCache, "testFolder/file3.asset").createNewFile()
+            new File(projectCache, ".last_renew").text = System.currentTimeMillis().toString()
+        }
+        jenkins.workspaceRoot.with {
+            new File(it, "testFolder/Subfolder/file1.txt").with {
+                it.parentFile.mkdirs()
+                it.createNewFile()
+            }
+        }
+        def cache = new Cache(jenkins, cacheRoot.absolutePath, "project", true)
+
+        when: "renewProjectCache is called with a closure that generates assets"
+        def success = cache.loadFromCache("testFolder")
+
+        then:
+        !success
+        jenkins.shInvocations.size() > 0
+        jenkins.shInvocations.collect{it.script.toString()}.with { _ ->
+            assert count {it.matches("^.*gtar\\s.+'${cacheRoot.absolutePath}/project/branch' -c 'testFolder/'.*\$") } == 1
+            assert count {it.matches("^.*rsync\\s.+'${cacheRoot.absolutePath}/project/branch/testFolder/' 'testFolder'.*\$") } == 1
+        }
+        !new File(jenkins.workspaceRoot,'project/branch/testFolder').exists()
         cleanup:
         jenkins.workspaceRoot.deleteDir()
         cacheRoot.deleteDir()


### PR DESCRIPTION
## Description
Sometimes rsync just fails when copying from cache into project. For those, we just delete the current project contents and pull from cache again. This new copy should use gtar which will be slower overall, but has more reliable results. If this second copy fails anyway, we delete whatever we were trying to uncache and move on. 

## Changes
* ![IMPROVE] More robust Cache failures




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
