### PR TITLE
[ATLAS-2349] javalibs now set java 17 as default for publish and checks

### DIFF
--- a/vars/javaLibs.groovy
+++ b/vars/javaLibs.groovy
@@ -69,6 +69,9 @@ def call(Map configMap = [:], Closure stepsConfigCls) {
           beforeAgent true
           expression { return actions.check.runWhenOrElse { env.RELEASE_TYPE == "snapshot" } }
         }
+        environment {
+          JAVA_HOME = "$JAVA_17_HOME"
+        }
 
         steps {
           script {
@@ -101,13 +104,13 @@ def call(Map configMap = [:], Closure stepsConfigCls) {
         agent {
           label "$mainPlatform && atlas"
         }
-
         environment {
           GRGIT                 = credentials('github_access')
           GRGIT_USER            = "${GRGIT_USR}"
           GRGIT_PASS            = "${GRGIT_PSW}"
           GITHUB_LOGIN          = "${GRGIT_USR}"
           GITHUB_PASSWORD       = "${GRGIT_PSW}"
+          JAVA_HOME             = "$JAVA_17_HOME"
         }
 
 


### PR DESCRIPTION
## Description

Now using java 17 as default for java pipelines. This should be 99% compatible with the current ones, with the only change required being to add the test exemptions to private variable access protection introduced in java 14.
```
        project.tasks.withType(Test).configureEach { Test test ->
            test.jvmArgs '--add-opens', 'java.base/java.util=ALL-UNNAMED'
            test.jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
        }
        ```

## Changes
* ![UPDATE] java version in java libraries to 17




[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
