### PR TITLE
[AD-36133] Fix DotnetNugetConfig sandbox rejection on static init

### DIFF
--- a/src/net/wooga/jenkins/pipeline/config/DotnetNugetConfig.groovy
+++ b/src/net/wooga/jenkins/pipeline/config/DotnetNugetConfig.groovy
@@ -12,11 +12,19 @@ package net.wooga.jenkins.pipeline.config
  */
 class DotnetNugetConfig {
 
-    static final DotnetNugetConfig standard = new DotnetNugetConfig(
-            "wooga_nuget",
-            "https://wooga.jfrog.io/artifactory/api/nuget/v3/wooga_nuget/index.json",
-            "artifactory_read"
-    )
+    /**
+     * Lazily constructed rather than a static final field: a static initializer
+     * calling `new DotnetNugetConfig(...)` gets classloaded (and its `new` call
+     * sandbox-checked) the first time an untrusted Jenkinsfile triggers this
+     * class, which script-security rejects even though this library is trusted.
+     */
+    static DotnetNugetConfig standard() {
+        return new DotnetNugetConfig(
+                "wooga_nuget",
+                "https://wooga.jfrog.io/artifactory/api/nuget/v3/wooga_nuget/index.json",
+                "artifactory_read"
+        )
+    }
 
     final String sourceName
     final String sourceUrl

--- a/test/groovy/net/wooga/jenkins/pipeline/config/DotnetNugetConfigSpec.groovy
+++ b/test/groovy/net/wooga/jenkins/pipeline/config/DotnetNugetConfigSpec.groovy
@@ -6,17 +6,17 @@ class DotnetNugetConfigSpec extends Specification {
 
     def "mergeWithConfigMap keeps the defaults when the map has no overrides"() {
         given:
-        def merged = DotnetNugetConfig.standard.mergeWithConfigMap([:])
+        def merged = DotnetNugetConfig.standard().mergeWithConfigMap([:])
 
         expect:
-        merged.sourceName == DotnetNugetConfig.standard.sourceName
-        merged.sourceUrl == DotnetNugetConfig.standard.sourceUrl
-        merged.credentialsId == DotnetNugetConfig.standard.credentialsId
+        merged.sourceName == DotnetNugetConfig.standard().sourceName
+        merged.sourceUrl == DotnetNugetConfig.standard().sourceUrl
+        merged.credentialsId == DotnetNugetConfig.standard().credentialsId
     }
 
     def "mergeWithConfigMap overrides individual fields given in the map"() {
         given:
-        def merged = DotnetNugetConfig.standard.mergeWithConfigMap([
+        def merged = DotnetNugetConfig.standard().mergeWithConfigMap([
                 nugetSourceName   : "custom_source",
                 nugetSourceUrl    : "https://example.com/index.json",
                 nugetCredentialsId: "custom_creds",
@@ -30,7 +30,7 @@ class DotnetNugetConfigSpec extends Specification {
 
     def "mergeWithConfigMap returns an empty config when nuget: false"() {
         given:
-        def merged = DotnetNugetConfig.standard.mergeWithConfigMap([nuget: false, nugetSourceName: "ignored"])
+        def merged = DotnetNugetConfig.standard().mergeWithConfigMap([nuget: false, nugetSourceName: "ignored"])
 
         expect:
         merged.sourceName == null

--- a/vars/dotnetWrapper.groovy
+++ b/vars/dotnetWrapper.groovy
@@ -6,12 +6,12 @@ import net.wooga.jenkins.pipeline.config.DotnetNugetConfig
  * installs the requested .NET SDK and executes `dotnet <command>` against it
  */
 def call(String command, Boolean returnStatus = false, Boolean returnStdout = false) {
-    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard.toDotnetArgs())
+    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard().toDotnetArgs())
     runCommand(dotnet, command, returnStatus, returnStdout)
 }
 
 def call(Map args) {
-    def nuget = DotnetNugetConfig.standard.mergeWithConfigMap(args)
+    def nuget = DotnetNugetConfig.standard().mergeWithConfigMap(args)
     def dotnet = Dotnet.fromJenkins(this, args + nuget.toDotnetArgs())
     runCommand(dotnet, args.command?.toString(),
             (args.returnStatus ?: false) as Boolean,

--- a/vars/runDotnetTool.groovy
+++ b/vars/runDotnetTool.groovy
@@ -7,12 +7,12 @@ import net.wooga.jenkins.pipeline.config.DotnetNugetConfig
  * tool, and runs toolBinary against it via `dotnet tool run`
  */
 def call(String packageId, String toolBinary, List<String> args = []) {
-    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard.toDotnetArgs())
+    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard().toDotnetArgs())
     return dotnet.runTool(packageId, toolBinary, args, null, false)
 }
 
 def call(Map args) {
-    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard.toDotnetArgs())
+    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard().toDotnetArgs())
     return dotnet.runTool(
             args.packageId?.toString(),
             args.toolBinary?.toString(),

--- a/vars/withDotnet.groovy
+++ b/vars/withDotnet.groovy
@@ -6,7 +6,7 @@ import net.wooga.jenkins.pipeline.config.DotnetNugetConfig
  * installs the requested .NET SDK and runs the given block with it on PATH
  */
 def call(Map config = [:], Closure block) {
-    def nuget = DotnetNugetConfig.standard.mergeWithConfigMap(config)
+    def nuget = DotnetNugetConfig.standard().mergeWithConfigMap(config)
     def dotnet = Dotnet.fromJenkins(this, config + nuget.toDotnetArgs())
     dotnet.withInstalledDotnet(block)
 }

--- a/vars/withDotnetTool.groovy
+++ b/vars/withDotnetTool.groovy
@@ -7,11 +7,11 @@ import net.wooga.jenkins.pipeline.config.DotnetNugetConfig
  * tool, and runs the given block with it invocable via `dotnet tool run`
  */
 def call(String packageId, Closure block) {
-    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard.toDotnetArgs())
+    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard().toDotnetArgs())
     return dotnet.withTool(packageId, null, block)
 }
 
 def call(Map opts, Closure block) {
-    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard.toDotnetArgs())
+    def dotnet = Dotnet.fromJenkins(this, DotnetNugetConfig.standard().toDotnetArgs())
     return dotnet.withTool(opts.packageId?.toString(), opts.version as String, block)
 }


### PR DESCRIPTION
## Description
`DotnetNugetConfig.standard` was a `static final` field eagerly constructed via `new DotnetNugetConfig(...)` in the class's static initializer. Jenkins' script-security sandbox subjects static initializers to whitelist checks regardless of the calling library's trust level, so the first untrusted Jenkinsfile to trigger this class's classload rejected the constructor:

```
org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use new net.wooga.jenkins.pipeline.config.DotnetNugetConfig java.lang.String java.lang.String java.lang.String
    at ...DotnetNugetConfig.<clinit>(DotnetNugetConfig.groovy:16)
```

This surfaced in `wooga/adventure5-tools` PR #402, which was the first caller to set `useDotnetTool = true` on a `buildContentJob`/`adventure5Tools` step, triggering the classload path through `withDotnet`/`withDotnetTool`/`dotnetWrapper`/`runDotnetTool`.

## Changes
* ![FIX] `DotnetNugetConfig.standard` static field &rarr; lazily-invoked `standard()` static method, so the constructor runs at actual use time instead of classload time
* ![FIX] update the `withDotnet`, `withDotnetTool`, `dotnetWrapper`, `runDotnetTool` call sites and `DotnetNugetConfigSpec` from `.standard` to `.standard()`

## Notes
`PipelineConventions.standard` (`src/net/wooga/jenkins/pipeline/config/PipelineConventions.groovy`) has the identical eager-`new`-in-static-field pattern and is used as a default parameter value across `JavaChecks`/`WDKChecks`/`JSChecks`/`Publishers`/`Setups`. It hasn't been observed failing (likely already script-approved on the masters that exercise it), but carries the same latent risk. Left out of this PR to keep the fix surgical — happy to follow up separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)